### PR TITLE
Capture `window/logMessage` messages

### DIFF
--- a/lib/pytest-lsp/changes/5.feature.rst
+++ b/lib/pytest-lsp/changes/5.feature.rst
@@ -1,0 +1,1 @@
+Any ``window/logMessage`` messages emitted by a server under test are now captured and reported alongside any test failures

--- a/lib/pytest-lsp/pytest_lsp/__init__.py
+++ b/lib/pytest-lsp/pytest_lsp/__init__.py
@@ -2,6 +2,8 @@ from .client import Client
 from .client import make_test_client
 from .plugin import fixture
 from .plugin import make_client_server
+from .plugin import pytest_runtest_makereport
+
 from .plugin import ClientServer
 from .plugin import ClientServerConfig
 
@@ -14,4 +16,5 @@ __all__ = [
     "fixture",
     "make_client_server",
     "make_test_client",
+    "pytest_runtest_makereport",
 ]


### PR DESCRIPTION
Any `window/logMessage` messages emitted by a server during a test are now reported when a test fails.

```
_______________ test_document_symbols[neovim-theorems/pythagoras.rst-expected1] _______________

...
    async def test_document_symbols(client: Client, filepath: str, expected):
        """Ensure that we handle ``textDocument/documentSymbols`` requests correctly"""
    
        test_uri = client.root_uri + f"/{filepath}"
        symbols = await client.document_symbols_request(test_uri)
    
>       assert symbols == expected
E       assert [DocumentSymb...recated=None)] == [DocumentSymb...recated=None)]
E         At index 0 diff: DocumentSymbol(name="Pythagoras' Theorem", kind=<SymbolKind.String: 15>, range=3:0-3:18, selection_range=3:0-3:18, detail=None, children=[DocumentSymbol(name='.. include:: ../math.rst', kind=<SymbolKind.Class: 5>, range=8:0-8:23, selection_range=8:0-8:23, detail=None, children=[], tags=None, deprecated=None), DocumentSymbol(name='.. include:: /math.rst', kind=<SymbolKind.Class: 5>, range=10:0-10:21, selection_range=10:0-10:21, detail=None, children=[], tags=None, deprecated=None), DocumentSymbol(name='Implementation', kind=<SymbolKind.String: 15>, range...
E         
E         ...Full output truncated (2 lines hidden), use '-vv' to show

tests/sphinx-default/test_sd_symbols.py:140: AssertionError
------------------------------ Captured window/logMessages setup ------------------------------
DEBUG: [esbonio.lsp] Loaded module 'esbonio.lsp.directives'
DEBUG: [esbonio.lsp] Loaded module 'esbonio.lsp.roles'
DEBUG: [esbonio.lsp] Loaded module 'esbonio.lsp.rst.directives'
DEBUG: [esbonio.lsp] Loaded module 'esbonio.lsp.rst.roles'
DEBUG: [esbonio.lsp] Loaded module 'esbonio.lsp.sphinx.codeblocks'
...
DEBUG: [esbonio.lsp] Found 3 problems for file:///var/home/alex/Projects/esbonio/lib/esbonio/tests/sphinx-default/workspace/directive_options.rst
DEBUG: [esbonio.lsp] Publishing 2 diagnostics for: file:///var/home/alex/Projects/esbonio/lib/esbonio/tests/sphinx-default/workspace/definitions.rst
DEBUG: [esbonio.lsp] Publishing 2 diagnostics for: file:///var/home/alex/Projects/esbonio/lib/esbonio/tests/sphinx-default/workspace/directive_options.rst
DEBUG: [esbonio.lsp] filename is /var/home/alex/Projects/esbonio/lib/esbonio/tests/sphinx-default/workspace/conf.py
------------------------------ Captured window/logMessages call -------------------------------
DEBUG: [esbonio.lsp] filename is /var/home/alex/Projects/esbonio/lib/esbonio/tests/sphinx-default/workspace/theorems/pythagoras.rst
DEBUG: [esbonio.lsp] Getting initial doctree for: '/var/home/alex/Projects/esbonio/lib/esbonio/tests/sphinx-default/workspace/theorems/pythagoras.rst'
```
Any messages emitted during server startup are also attached to each test case for reference