### PR TITLE
pytest-lsp: Raise exception if the tested LSP server doesn't start

### DIFF
--- a/lib/pytest-lsp/changes/22.fix.rst
+++ b/lib/pytest-lsp/changes/22.fix.rst
@@ -1,0 +1,2 @@
+- Check that server provided for testing doesn't crash within the first 0.1 seconds
+- Return `INITIALIZE` response from `ClientServer.start()`. This allows tests to assert against the server's `INITIALIZE` response without resending the `INITIALIZE` request in the actual test.

--- a/lib/pytest-lsp/pytest_lsp/plugin.py
+++ b/lib/pytest-lsp/pytest_lsp/plugin.py
@@ -95,7 +95,7 @@ class ClientServer:
         assert "capabilities" in response
         self.client.lsp.notify(INITIALIZED)
 
-        return
+        return response
 
     async def stop(self):
         response = await self.client.lsp.send_request_async(SHUTDOWN)

--- a/lib/pytest-lsp/pytest_lsp/plugin.py
+++ b/lib/pytest-lsp/pytest_lsp/plugin.py
@@ -178,6 +178,19 @@ def make_client_server(config: ClientServerConfig) -> ClientServer:
         config.server_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE
     )
 
+    try:
+        # Timeout is arbitrary, because we'd also like to know if the server crashes
+        # in the future. But this is useful because if the server is going to crash
+        # it will most likely do it in the first few milliseconds of startup.
+        server.wait(timeout=0.1)
+    except subprocess.TimeoutExpired:
+        pass
+    finally:
+        if server.returncode is not None:
+            raise Exception(
+                f"{config.server_command} exited with exit code {server.returncode}"
+            )
+
     if config.client_capabilities:
         capabilities = config.client_capabilities
     elif config.client:


### PR DESCRIPTION
Hey Alex!

First off this is such a great set of tools for the LSP/Pygls ecosystem ❤️ I'm continuously impressed by the comprehensiveness and high quality of your code 🤓 Thanks for making it public. I know this project is young, but very useful nonetheless.

So, in order to be a better, more informed maintainer of Pygls, I've set out to build my own LSP server! It's also going to double as a reasonable starter template for new Pygls projects: https://github.com/tombh/cli-tools-lsp I was looking around for a good way to do end to end tests and of course I ended up here 😏 

I don't know if this PR is at all the right way to go about addressing my little issue. But nevertheless it highlights the blindspot I hit, namely that I didn't get any feedback that my LSP server wasn't even booting. For sure I know this isn't a complete solution to handling a failed LSP server, because it only detects failure within the first 0.1 seconds of startup, but it's useful to catch the common case of the server not even booting.