### PR TITLE
Migrate to Pygls v1.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+name: Documentation
+on:
+  pull_request:
+    branches:
+    - release
+    - develop
+    paths:
+    - 'docs/**'
+    - 'lib/pytest-lsp/**'
+  push:
+    branches:
+    - release
+    - develop
+    paths:
+    - 'docs/**'
+    - 'lib/pytest-lsp/**'
+
+jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - run: |
+        set -e
+
+        python --version
+        python -m pip install --upgrade pip
+        python -m pip install -r docs/requirements.txt
+
+      name: Setup Environment
+
+    - id: build
+      run: |
+        set -e
+
+        cd docs
+        make html
+      name: Build Docs
+
+    - name: 'Upload Aritfact'
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'docs'
+        path: 'docs/_build/${{ steps.build.outputs.version }}'
+
+    - name: 'Publish Docs'
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages
+        folder: docs/_build/${{ steps.build.outputs.version }}
+        target-folder: docs/${{ steps.build.outputs.version }}
+        clean: true
+      if: success() && ( startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/develop') )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 *.pyc
 
 dist
+build
 node_modules
 .mypy_cache
 __pycache__
 *.egg-info
+_build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,23 @@
+ifeq ($(CI),true)
+	BUILD=html-build
+else
+	BUILD=html-local
+endif
+
+
+ifeq ($(GITHUB_REF),refs/heads/release)
+	BUILDDIR=stable
+else
+	BUILDDIR=latest
+endif
+
+
+html-build:
+	BUILDDIR=$(BUILDDIR) sphinx-build -b html . _build/$(BUILDDIR)/en/
+	echo "::set-output name=version::$(BUILDDIR)"
+
+
+html-local:
+	sphinx-build -M html . _build $(SPHINXOPTS)
+
+html: $(BUILD)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,40 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'LSP Devtools'
+copyright = '2022, Alex Carney'
+author = 'Alex Carney'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+]
+
+autoclass_content = "both"
+autodoc_member_order = "groupwise"
+autodoc_typehints = "description"
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None)
+}
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'furo'
+html_title = "LSP Devtools"
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,60 @@
+LSP Devtools
+============
+
+The LSP Devtools project provides a number of tools that aim to make the
+process of developing language servers and clients easier.
+
+
+pytest-lsp
+----------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :hidden:
+   :caption: pytest-lsp
+
+   pytest-lsp/*
+
+End-to-end testing of language servers with pytest.
+
+.. note::
+
+   This plugin is in early development, it currently implements just enough to support the test suite of the
+   `esbonio <https://github.com/swyddfa/esbonio>`__
+   language server.
+
+``pytest-lsp`` is a pytest plugin for writing end-to-end tests for language servers.
+
+It works by running the language server in a subprocess and communicating with it over stdio, just like a real language client.
+This also means ``pytest-lsp`` can be used to test language servers written in any language - not just Python.
+
+``pytest-lsp`` relies on `pygls <https://github.com/openlawlibrary/pygls>`__ for its language server protocol implementation.
+
+.. code-block:: python
+
+   import sys
+   import pytest
+   import pytest_lsp
+   from pytest_lsp import ClientServerConfig
+
+
+   @pytest_lsp.fixture(
+       scope='session',
+       config=ClientServerConfig(
+           server_command=[sys.executable, "-m", "esbonio"],
+           root_uri="file:///path/to/test/project/root/"
+       ),
+   )
+   async def client():
+       pass
+
+
+   @pytest.mark.asyncio
+   async def test_completion(client):
+       test_uri="file:///path/to/test/project/root/test_file.rst"
+       result = await client.completion_request(test_uri, line=5, character=23)
+
+       assert len(result.items) > 0
+
+

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/pytest-lsp/getting-started.rst
+++ b/docs/pytest-lsp/getting-started.rst
@@ -1,0 +1,4 @@
+Getting Started
+===============
+
+Coming soon

--- a/docs/pytest-lsp/reference.rst
+++ b/docs/pytest-lsp/reference.rst
@@ -1,0 +1,21 @@
+API Reference
+=============
+
+.. currentmodule:: pytest_lsp
+
+.. autofunction:: fixture
+
+.. autofunction:: make_client_server
+
+.. autofunction:: make_test_client
+
+.. autoclass:: ClientServerConfig
+   :members:
+
+.. autoclass:: LanguageClient
+   :members:
+   :inherited-members:
+
+.. autoclass:: ClientServer
+   :members:
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+# This assumes you are running the pip install command from the root of the repo e.g.
+# $ pip install -r docs/requirements.txt
+sphinx
+furo
+-e lib/pytest-lsp

--- a/lib/pytest-lsp/changes/25.feature.rst
+++ b/lib/pytest-lsp/changes/25.feature.rst
@@ -1,0 +1,1 @@
+The ``LanguageClient`` now exposes methods covering the full LSP spec thanks to autogenerating its client from type definitions provided by ``lsprotocol``

--- a/lib/pytest-lsp/changes/25.misc.rst
+++ b/lib/pytest-lsp/changes/25.misc.rst
@@ -1,3 +1,5 @@
 Support for Python 3.6 has been dropped.
 
+Support for Python 3.11 has been added.
+
 Upgraded to pygls 1.0.

--- a/lib/pytest-lsp/changes/25.misc.rst
+++ b/lib/pytest-lsp/changes/25.misc.rst
@@ -1,0 +1,3 @@
+Support for Python 3.6 has been dropped.
+
+Upgraded to pygls 1.0.

--- a/lib/pytest-lsp/pyproject.toml
+++ b/lib/pytest-lsp/pyproject.toml
@@ -52,7 +52,7 @@ legacy_tox_ini = """
 [tox]
 isolated_build = True
 skip_missing_interpreters = true
-envlist = py{37,38,39,310}
+envlist = py{37,38,39,310,311}
 
 [testenv]
 extras= dev

--- a/lib/pytest-lsp/pyproject.toml
+++ b/lib/pytest-lsp/pyproject.toml
@@ -52,7 +52,7 @@ legacy_tox_ini = """
 [tox]
 isolated_build = True
 skip_missing_interpreters = true
-envlist = py{36,37,38,39,310}
+envlist = py{37,38,39,310}
 
 [testenv]
 extras= dev

--- a/lib/pytest-lsp/pytest_lsp/__init__.py
+++ b/lib/pytest-lsp/pytest_lsp/__init__.py
@@ -1,4 +1,4 @@
-from .client import Client
+from .client import LanguageClient
 from .client import make_test_client
 from .plugin import fixture
 from .plugin import make_client_server
@@ -10,9 +10,9 @@ from .plugin import ClientServerConfig
 __version__ = "0.1.3"
 
 __all__ = [
-    "Client",
     "ClientServer",
     "ClientServerConfig",
+    "LanguageClient",
     "fixture",
     "make_client_server",
     "make_test_client",

--- a/lib/pytest-lsp/pytest_lsp/check.py
+++ b/lib/pytest-lsp/pytest_lsp/check.py
@@ -2,27 +2,36 @@
 import logging
 from typing import List
 
-from pygls.lsp.types import *
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import DocumentLink
+from lsprotocol.types import InsertTextFormat
+from lsprotocol.types import MarkupContent
+from pygls.capabilities import get_capability
 
-from pytest_lsp.client import Client
+from pytest_lsp.client import LanguageClient
 
 logger = logging.getLogger(__name__)
 
 
-def completion_items(client: Client, items: List[CompletionItem]):
+def completion_items(client: LanguageClient, items: List[CompletionItem]):
     """Ensure that the completion items returned from the server are compliant with the
     spec and the client's declared capabilities."""
 
-    commit_characters_support = client.capabilities.get_capability(
-        "text_document.completion.completion_item.commit_characters_support", False
+    commit_characters_support = get_capability(
+        client.capabilities,
+        "text_document.completion.completion_item.commit_characters_support",
+        False
     )
     documentation_formats = set(
-        client.capabilities.get_capability(
+        get_capability(
+            client.capabilities,
             "text_document.completion.completion_item.documentation_format", []
         )
     )
-    snippet_support = client.capabilities.get_capability(
-        "text_document.completion.completion_item.snippet_support", False
+    snippet_support = get_capability(
+        client.capabilities,
+        "text_document.completion.completion_item.snippet_support",
+        False
     )
 
     for item in items:
@@ -42,12 +51,14 @@ def completion_items(client: Client, items: List[CompletionItem]):
             assert snippet_support, "Client does not support snippets."
 
 
-def document_links(client: Client, items: List[DocumentLink]):
+def document_links(client: LanguageClient, items: List[DocumentLink]):
     """Ensure that the document links returned from the server are compliant with the
     spec and the client's declared capabilities."""
 
-    tooltip_support = client.capabilities.get_capability(
-        "text_document.document_link.tooltip_support", False
+    tooltip_support = get_capability(
+        client.capabilities,
+        "text_document.document_link.tooltip_support",
+        False
     )
 
     for item in items:

--- a/lib/pytest-lsp/pytest_lsp/client.py
+++ b/lib/pytest-lsp/pytest_lsp/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sys
 import traceback
 from concurrent.futures import Future
 from typing import Any
@@ -172,7 +173,7 @@ class LanguageClient(Client):
             return
 
         self.error = error
-        tb = "".join(traceback.format_exception(error))
+        tb = "".join(traceback.format_exc())
 
         message = f"{source.__name__}: {error}\n{tb}"
         self._control_loop.call_soon_threadsafe(cancel_all_tasks, message)
@@ -521,7 +522,10 @@ def cancel_all_tasks(message: str):
     """Called by the watchdog thread to cancel all awaited tasks."""
 
     for task in asyncio.all_tasks():
-        task.cancel(message)
+        if sys.version_info.minor < 9:
+            task.cancel()
+        else:
+            task.cancel(message)
 
 
 def make_test_client(capabilities: ClientCapabilities, root_uri: str) -> LanguageClient:

--- a/lib/pytest-lsp/pytest_lsp/clients/neovim_v0.6.1.json
+++ b/lib/pytest-lsp/pytest_lsp/clients/neovim_v0.6.1.json
@@ -1,23 +1,17 @@
 {
   "workspace": {
-    "apply_edit": true,
-    "workspace_edit": {
-      "document_changes": null,
-      "resource_operations": [
+    "applyEdit": true,
+    "workspaceEdit": {
+      "resourceOperations": [
         "rename",
         "create",
         "delete"
-      ],
-      "failure_handling": null,
-      "normalizes_line_endings": null,
-      "change_annotation_support": null
+      ]
     },
-    "did_change_configuration": null,
-    "did_change_watched_files": null,
     "symbol": {
-      "dynamic_registration": false,
-      "symbol_kind": {
-        "value_set": [
+      "dynamicRegistration": false,
+      "symbolKind": {
+        "valueSet": [
           1,
           2,
           3,
@@ -45,41 +39,32 @@
           25,
           26
         ]
-      },
-      "tag_support": null
+      }
     },
-    "execute_command": null,
-    "workspace_folders": true,
-    "configuration": true,
-    "semantic_tokens": null,
-    "code_lens": null,
-    "file_operations": null
+    "workspaceFolders": true,
+    "configuration": true
   },
-  "text_document": {
+  "textDocument": {
     "synchronization": {
-      "dynamic_registration": false,
-      "will_save": false,
-      "will_save_wait_until": false,
-      "did_save": true
+      "dynamicRegistration": false,
+      "willSave": false,
+      "willSaveWaitUntil": false,
+      "didSave": true
     },
     "completion": {
-      "dynamic_registration": false,
-      "completion_item": {
-        "snippet_support": false,
-        "commit_characters_support": false,
-        "documentation_format": [
+      "dynamicRegistration": false,
+      "completionItem": {
+        "snippetSupport": false,
+        "commitCharactersSupport": false,
+        "documentationFormat": [
           "markdown",
           "plaintext"
         ],
-        "deprecated_support": false,
-        "preselect_support": false,
-        "tag_support": null,
-        "insert_replace_support": null,
-        "resolve_support": null,
-        "insert_text_mode_support": null
+        "deprecatedSupport": false,
+        "preselectSupport": false
       },
-      "completion_item_kind": {
-        "value_set": [
+      "completionItemKind": {
+        "valueSet": [
           1,
           2,
           3,
@@ -107,55 +92,50 @@
           25
         ]
       },
-      "context_support": false
+      "contextSupport": false
     },
     "hover": {
-      "dynamic_registration": false,
-      "content_format": [
+      "dynamicRegistration": false,
+      "contentFormat": [
         "markdown",
         "plaintext"
       ]
     },
-    "signature_help": {
-      "dynamic_registration": false,
-      "signature_information": {
-        "documentation_format": [
+    "signatureHelp": {
+      "dynamicRegistration": false,
+      "signatureInformation": {
+        "documentationFormat": [
           "markdown",
           "plaintext"
         ],
-        "parameter_information": {
-          "label_offset_support": true
+        "parameterInformation": {
+          "labelOffsetSupport": true
         },
-        "active_parameter_support": true
-      },
-      "context_support": null
+        "activeParameterSupport": true
+      }
     },
     "declaration": {
-      "dynamic_registration": null,
-      "link_support": true
+      "linkSupport": true
     },
     "definition": {
-      "dynamic_registration": null,
-      "link_support": true
+      "linkSupport": true
     },
-    "type_definition": {
-      "dynamic_registration": null,
-      "link_support": true
+    "typeDefinition": {
+      "linkSupport": true
     },
     "implementation": {
-      "dynamic_registration": null,
-      "link_support": true
+      "linkSupport": true
     },
     "references": {
-      "dynamic_registration": false
+      "dynamicRegistration": false
     },
-    "document_highlight": {
-      "dynamic_registration": false
+    "documentHighlight": {
+      "dynamicRegistration": false
     },
-    "document_symbol": {
-      "dynamic_registration": false,
-      "symbol_kind": {
-        "value_set": [
+    "documentSymbol": {
+      "dynamicRegistration": false,
+      "symbolKind": {
+        "valueSet": [
           1,
           2,
           3,
@@ -184,15 +164,13 @@
           26
         ]
       },
-      "hierarchical_document_symbol_support": true,
-      "tag_support": null,
-      "label_support": null
+      "hierarchicalDocumentSymbolSupport": true
     },
-    "code_action": {
-      "dynamic_registration": false,
-      "code_action_literal_support": {
-        "code_action_kind": {
-          "value_set": [
+    "codeAction": {
+      "dynamicRegistration": false,
+      "codeActionLiteralSupport": {
+        "codeActionKind": {
+          "valueSet": [
             "",
             "Empty",
             "QuickFix",
@@ -212,58 +190,36 @@
           ]
         }
       },
-      "is_preferred_support": null,
-      "disabled_support": null,
-      "data_support": true,
-      "resolve_support": {
+      "dataSupport": true,
+      "resolveSupport": {
         "properties": [
           "edit"
         ]
-      },
-      "honors_change_annotations": null
+      }
     },
-    "code_lens": null,
-    "document_link": null,
-    "color_provider": null,
-    "formatting": null,
-    "range_formatting": null,
-    "on_type_formatting": null,
     "rename": {
-      "dynamic_registration": false,
-      "prepare_support": true,
-      "prepare_support_default_behavior": null,
-      "honors_change_annotations": null
+      "dynamicRegistration": false,
+      "prepareSupport": true
     },
-    "publish_diagnostics": {
-      "related_information": true,
-      "tag_support": {
-        "value_set": [
+    "publishDiagnostics": {
+      "relatedInformation": true,
+      "tagSupport": {
+        "valueSet": [
           1,
           2
         ]
-      },
-      "version_support": null,
-      "code_description_support": null,
-      "data_support": null
-    },
-    "folding_range": null,
-    "selection_range": null,
-    "linked_editing_range": null,
-    "call_hierarchy": null,
-    "semantic_tokens": null,
-    "moniker": null
-  },
-  "window": {
-    "work_done_progress": true,
-    "show_message": {
-      "message_action_item": {
-        "additional_properties_support": false
       }
-    },
-    "show_document": {
-      "support": false
     }
   },
-  "general": null,
-  "experimental": null
+  "window": {
+    "workDoneProgress": true,
+    "showMessage": {
+      "messageActionItem": {
+        "additionalPropertiesSupport": false
+      }
+    },
+    "showDocument": {
+      "support": false
+    }
+  }
 }

--- a/lib/pytest-lsp/pytest_lsp/clients/visual_studio_code_v1.65.2.json
+++ b/lib/pytest-lsp/pytest_lsp/clients/visual_studio_code_v1.65.2.json
@@ -1,29 +1,29 @@
 {
   "workspace": {
-    "apply_edit": true,
-    "workspace_edit": {
-      "document_changes": true,
-      "resource_operations": [
+    "applyEdit": true,
+    "workspaceEdit": {
+      "documentChanges": true,
+      "resourceOperations": [
         "create",
         "rename",
         "delete"
       ],
-      "failure_handling": "textOnlyTransactional",
-      "normalizes_line_endings": true,
-      "change_annotation_support": {
-        "groups_on_label": true
+      "failureHandling": "textOnlyTransactional",
+      "normalizesLineEndings": true,
+      "changeAnnotationSupport": {
+        "groupsOnLabel": true
       }
     },
-    "did_change_configuration": {
-      "dynamic_registration": true
+    "didChangeConfiguration": {
+      "dynamicRegistration": true
     },
-    "did_change_watched_files": {
-      "dynamic_registration": true
+    "didChangeWatchedFiles": {
+      "dynamicRegistration": true
     },
     "symbol": {
-      "dynamic_registration": true,
-      "symbol_kind": {
-        "value_set": [
+      "dynamicRegistration": true,
+      "symbolKind": {
+        "valueSet": [
           1,
           2,
           3,
@@ -52,73 +52,73 @@
           26
         ]
       },
-      "tag_support": {
-        "value_set": [
+      "tagSupport": {
+        "valueSet": [
           1
         ]
       }
     },
-    "execute_command": {
-      "dynamic_registration": true
+    "executeCommand": {
+      "dynamicRegistration": true
     },
-    "workspace_folders": true,
+    "workspaceFolders": true,
     "configuration": true,
-    "semantic_tokens": {
-      "refresh_support": true
+    "semanticTokens": {
+      "refreshSupport": true
     },
-    "code_lens": {
-      "refresh_support": true
+    "codeLens": {
+      "refreshSupport": true
     },
-    "file_operations": {
-      "dynamic_registration": true,
-      "did_create": true,
-      "will_create": true,
-      "did_rename": true,
-      "will_rename": true,
-      "did_delete": true,
-      "will_delete": true
+    "fileOperations": {
+      "dynamicRegistration": true,
+      "didCreate": true,
+      "willCreate": true,
+      "didRename": true,
+      "willRename": true,
+      "didDelete": true,
+      "willDelete": true
     }
   },
-  "text_document": {
+  "textDocument": {
     "synchronization": {
-      "dynamic_registration": true,
-      "will_save": true,
-      "will_save_wait_until": true,
-      "did_save": true
+      "dynamicRegistration": true,
+      "willSave": true,
+      "willSaveWaitUntil": true,
+      "didSave": true
     },
     "completion": {
-      "dynamic_registration": true,
-      "completion_item": {
-        "snippet_support": true,
-        "commit_characters_support": true,
-        "documentation_format": [
+      "dynamicRegistration": true,
+      "completionItem": {
+        "snippetSupport": true,
+        "commitCharactersSupport": true,
+        "documentationFormat": [
           "markdown",
           "plaintext"
         ],
-        "deprecated_support": true,
-        "preselect_support": true,
-        "tag_support": {
-          "value_set": [
+        "deprecatedSupport": true,
+        "preselectSupport": true,
+        "tagSupport": {
+          "valueSet": [
             1
           ]
         },
-        "insert_replace_support": true,
-        "resolve_support": {
+        "insertReplaceSupport": true,
+        "resolveSupport": {
           "properties": [
             "documentation",
             "detail",
             "additionalTextEdits"
           ]
         },
-        "insert_text_mode_support": {
-          "value_set": [
+        "insertTextModeSupport": {
+          "valueSet": [
             1,
             2
           ]
         }
       },
-      "completion_item_kind": {
-        "value_set": [
+      "completionItemKind": {
+        "valueSet": [
           1,
           2,
           3,
@@ -146,55 +146,55 @@
           25
         ]
       },
-      "context_support": true
+      "contextSupport": true
     },
     "hover": {
-      "dynamic_registration": true,
-      "content_format": [
+      "dynamicRegistration": true,
+      "contentFormat": [
         "markdown",
         "plaintext"
       ]
     },
-    "signature_help": {
-      "dynamic_registration": true,
-      "signature_information": {
-        "documentation_format": [
+    "signatureHelp": {
+      "dynamicRegistration": true,
+      "signatureInformation": {
+        "documentationFormat": [
           "markdown",
           "plaintext"
         ],
-        "parameter_information": {
-          "label_offset_support": true
+        "parameterInformation": {
+          "labelOffsetSupport": true
         },
-        "active_parameter_support": true
+        "activeParameterSupport": true
       },
-      "context_support": true
+      "contextSupport": true
     },
     "declaration": {
-      "dynamic_registration": true,
-      "link_support": true
+      "dynamicRegistration": true,
+      "linkSupport": true
     },
     "definition": {
-      "dynamic_registration": true,
-      "link_support": true
+      "dynamicRegistration": true,
+      "linkSupport": true
     },
-    "type_definition": {
-      "dynamic_registration": true,
-      "link_support": true
+    "typeDefinition": {
+      "dynamicRegistration": true,
+      "linkSupport": true
     },
     "implementation": {
-      "dynamic_registration": true,
-      "link_support": true
+      "dynamicRegistration": true,
+      "linkSupport": true
     },
     "references": {
-      "dynamic_registration": true
+      "dynamicRegistration": true
     },
-    "document_highlight": {
-      "dynamic_registration": true
+    "documentHighlight": {
+      "dynamicRegistration": true
     },
-    "document_symbol": {
-      "dynamic_registration": true,
-      "symbol_kind": {
-        "value_set": [
+    "documentSymbol": {
+      "dynamicRegistration": true,
+      "symbolKind": {
+        "valueSet": [
           1,
           2,
           3,
@@ -223,19 +223,19 @@
           26
         ]
       },
-      "hierarchical_document_symbol_support": true,
-      "tag_support": {
-        "value_set": [
+      "hierarchicalDocumentSymbolSupport": true,
+      "tagSupport": {
+        "valueSet": [
           1
         ]
       },
-      "label_support": true
+      "labelSupport": true
     },
-    "code_action": {
-      "dynamic_registration": true,
-      "code_action_literal_support": {
-        "code_action_kind": {
-          "value_set": [
+    "codeAction": {
+      "dynamicRegistration": true,
+      "codeActionLiteralSupport": {
+        "codeActionKind": {
+          "valueSet": [
             "",
             "quickfix",
             "refactor",
@@ -247,75 +247,75 @@
           ]
         }
       },
-      "is_preferred_support": true,
-      "disabled_support": true,
-      "data_support": true,
-      "resolve_support": {
+      "isPreferredSupport": true,
+      "disabledSupport": true,
+      "dataSupport": true,
+      "resolveSupport": {
         "properties": [
           "edit"
         ]
       },
-      "honors_change_annotations": false
+      "honorsChangeAnnotations": false
     },
-    "code_lens": {
-      "dynamic_registration": true
+    "codeLens": {
+      "dynamicRegistration": true
     },
-    "document_link": {
-      "dynamic_registration": true,
-      "tooltip_support": true
+    "documentLink": {
+      "dynamicRegistration": true,
+      "tooltipSupport": true
     },
-    "color_provider": {
-      "dynamic_registration": true
+    "colorProvider": {
+      "dynamicRegistration": true
     },
     "formatting": {
-      "dynamic_registration": true
+      "dynamicRegistration": true
     },
-    "range_formatting": {
-      "dynamic_registration": true
+    "rangeFormatting": {
+      "dynamicRegistration": true
     },
-    "on_type_formatting": {
-      "dynamic_registration": true
+    "onTypeFormatting": {
+      "dynamicRegistration": true
     },
     "rename": {
-      "dynamic_registration": true,
-      "prepare_support": true,
-      "prepare_support_default_behavior": 1,
-      "honors_change_annotations": true
+      "dynamicRegistration": true,
+      "prepareSupport": true,
+      "prepareSupportDefaultBehavior": 1,
+      "honorsChangeAnnotations": true
     },
-    "publish_diagnostics": {
-      "related_information": true,
-      "tag_support": {
-        "value_set": [
+    "publishDiagnostics": {
+      "relatedInformation": true,
+      "tagSupport": {
+        "valueSet": [
           1,
           2
         ]
       },
-      "version_support": false,
-      "code_description_support": true,
-      "data_support": true
+      "versionSupport": false,
+      "codeDescriptionSupport": true,
+      "dataSupport": true
     },
-    "folding_range": {
-      "dynamic_registration": true,
-      "range_limit": 5000,
-      "line_folding_only": true
+    "foldingRange": {
+      "dynamicRegistration": true,
+      "rangeLimit": 5000,
+      "lineFoldingOnly": true
     },
-    "selection_range": {
-      "dynamic_registration": true
+    "selectionRange": {
+      "dynamicRegistration": true
     },
-    "linked_editing_range": {
-      "dynamic_registration": true
+    "linkedEditingRange": {
+      "dynamicRegistration": true
     },
-    "call_hierarchy": {
-      "dynamic_registration": true
+    "callHierarchy": {
+      "dynamicRegistration": true
     },
-    "semantic_tokens": {
+    "semanticTokens": {
       "requests": {
         "range": true,
         "full": {
           "delta": true
         }
       },
-      "token_types": [
+      "tokenTypes": [
         "namespace",
         "type",
         "class",
@@ -339,7 +339,7 @@
         "regexp",
         "operator"
       ],
-      "token_modifiers": [
+      "tokenModifiers": [
         "declaration",
         "definition",
         "readonly",
@@ -354,25 +354,24 @@
       "formats": [
         "relative"
       ],
-      "overlapping_token_support": false,
-      "multiline_token_support": false,
-      "dynamic_registration": true
-    },
-    "moniker": null
+      "overlappingTokenSupport": false,
+      "multilineTokenSupport": false,
+      "dynamicRegistration": true
+    }
   },
   "window": {
-    "work_done_progress": true,
-    "show_message": {
-      "message_action_item": {
-        "additional_properties_support": true
+    "workDoneProgress": true,
+    "showMessage": {
+      "messageActionItem": {
+        "additionalPropertiesSupport": true
       }
     },
-    "show_document": {
+    "showDocument": {
       "support": true
     }
   },
   "general": {
-    "regular_expressions": {
+    "regularExpressions": {
       "engine": "ECMAScript",
       "version": "ES2020"
     },
@@ -380,6 +379,5 @@
       "parser": "marked",
       "version": "1.1.0"
     }
-  },
-  "experimental": null
+  }
 }

--- a/lib/pytest-lsp/pytest_lsp/gen.py
+++ b/lib/pytest-lsp/pytest_lsp/gen.py
@@ -1,0 +1,807 @@
+# GENERATED FROM scripts/gen-client.py -- DO NOT EDIT
+# Last Modified: 2022-12-16 22:34:06.577067
+import lsprotocol.types
+from lsprotocol.types import CallHierarchyIncomingCallsParams
+from lsprotocol.types import CallHierarchyOutgoingCallsParams
+from lsprotocol.types import CallHierarchyPrepareParams
+from lsprotocol.types import CancelParams
+from lsprotocol.types import CodeAction
+from lsprotocol.types import CodeActionParams
+from lsprotocol.types import CodeLens
+from lsprotocol.types import CodeLensParams
+from lsprotocol.types import ColorPresentationParams
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import CompletionParams
+from lsprotocol.types import CreateFilesParams
+from lsprotocol.types import CreateFilesParams
+from lsprotocol.types import DeclarationParams
+from lsprotocol.types import DefinitionParams
+from lsprotocol.types import DeleteFilesParams
+from lsprotocol.types import DeleteFilesParams
+from lsprotocol.types import DidChangeConfigurationParams
+from lsprotocol.types import DidChangeNotebookDocumentParams
+from lsprotocol.types import DidChangeTextDocumentParams
+from lsprotocol.types import DidChangeWatchedFilesParams
+from lsprotocol.types import DidChangeWorkspaceFoldersParams
+from lsprotocol.types import DidCloseNotebookDocumentParams
+from lsprotocol.types import DidCloseTextDocumentParams
+from lsprotocol.types import DidOpenNotebookDocumentParams
+from lsprotocol.types import DidOpenTextDocumentParams
+from lsprotocol.types import DidSaveNotebookDocumentParams
+from lsprotocol.types import DidSaveTextDocumentParams
+from lsprotocol.types import DocumentColorParams
+from lsprotocol.types import DocumentDiagnosticParams
+from lsprotocol.types import DocumentFormattingParams
+from lsprotocol.types import DocumentHighlightParams
+from lsprotocol.types import DocumentLink
+from lsprotocol.types import DocumentLinkParams
+from lsprotocol.types import DocumentOnTypeFormattingParams
+from lsprotocol.types import DocumentRangeFormattingParams
+from lsprotocol.types import DocumentSymbolParams
+from lsprotocol.types import ExecuteCommandParams
+from lsprotocol.types import FoldingRangeParams
+from lsprotocol.types import HoverParams
+from lsprotocol.types import ImplementationParams
+from lsprotocol.types import InitializeParams
+from lsprotocol.types import InitializedParams
+from lsprotocol.types import InlayHint
+from lsprotocol.types import InlayHintParams
+from lsprotocol.types import InlineValueParams
+from lsprotocol.types import LinkedEditingRangeParams
+from lsprotocol.types import MonikerParams
+from lsprotocol.types import PrepareRenameParams
+from lsprotocol.types import ProgressParams
+from lsprotocol.types import ReferenceParams
+from lsprotocol.types import RenameFilesParams
+from lsprotocol.types import RenameFilesParams
+from lsprotocol.types import RenameParams
+from lsprotocol.types import SelectionRangeParams
+from lsprotocol.types import SemanticTokensDeltaParams
+from lsprotocol.types import SemanticTokensParams
+from lsprotocol.types import SemanticTokensRangeParams
+from lsprotocol.types import SetTraceParams
+from lsprotocol.types import SignatureHelpParams
+from lsprotocol.types import TypeDefinitionParams
+from lsprotocol.types import TypeHierarchyPrepareParams
+from lsprotocol.types import TypeHierarchySubtypesParams
+from lsprotocol.types import TypeHierarchySupertypesParams
+from lsprotocol.types import WillSaveTextDocumentParams
+from lsprotocol.types import WillSaveTextDocumentParams
+from lsprotocol.types import WorkDoneProgressCancelParams
+from lsprotocol.types import WorkspaceDiagnosticParams
+from lsprotocol.types import WorkspaceSymbol
+from lsprotocol.types import WorkspaceSymbolParams
+from pygls.server import Server
+import typing
+
+
+class Client(Server):
+    """Used to drive the language server under test."""
+
+    async def call_hierarchy_incoming_calls_request(self, params: CallHierarchyIncomingCallsParams) -> typing.Optional[typing.List[lsprotocol.types.CallHierarchyIncomingCall]]:
+        """Make a ``callHierarchy/incomingCalls`` request.
+
+        A request to resolve the incoming calls for a given `CallHierarchyItem`.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("callHierarchy/incomingCalls", params)
+
+    async def call_hierarchy_outgoing_calls_request(self, params: CallHierarchyOutgoingCallsParams) -> typing.Optional[typing.List[lsprotocol.types.CallHierarchyOutgoingCall]]:
+        """Make a ``callHierarchy/outgoingCalls`` request.
+
+        A request to resolve the outgoing calls for a given `CallHierarchyItem`.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("callHierarchy/outgoingCalls", params)
+
+    async def code_action_resolve_request(self, params: CodeAction) -> lsprotocol.types.CodeAction:
+        """Make a ``codeAction/resolve`` request.
+
+        Request to resolve additional information for a given code action.The
+        request's parameter is of type CodeAction the response is of type
+        CodeAction or a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("codeAction/resolve", params)
+
+    async def code_lens_resolve_request(self, params: CodeLens) -> lsprotocol.types.CodeLens:
+        """Make a ``codeLens/resolve`` request.
+
+        A request to resolve a command for a given code lens.
+        """
+        return await self.lsp.send_request_async("codeLens/resolve", params)
+
+    async def completion_item_resolve_request(self, params: CompletionItem) -> lsprotocol.types.CompletionItem:
+        """Make a ``completionItem/resolve`` request.
+
+        Request to resolve additional information for a given completion
+        item.The request's parameter is of type CompletionItem the response is of
+        type CompletionItem or a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("completionItem/resolve", params)
+
+    async def document_link_resolve_request(self, params: DocumentLink) -> lsprotocol.types.DocumentLink:
+        """Make a ``documentLink/resolve`` request.
+
+        Request to resolve additional information for a given document link.
+
+        The request's parameter is of type DocumentLink the response is of
+        type DocumentLink or a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("documentLink/resolve", params)
+
+    async def initialize_request(self, params: InitializeParams) -> lsprotocol.types.InitializeResult:
+        """Make a ``initialize`` request.
+
+        The initialize request is sent from the client to the server.
+
+        It is sent once as the request after starting up the server. The
+        requests parameter is of type InitializeParams the response if of
+        type InitializeResult of a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("initialize", params)
+
+    async def inlay_hint_resolve_request(self, params: InlayHint) -> lsprotocol.types.InlayHint:
+        """Make a ``inlayHint/resolve`` request.
+
+        A request to resolve additional properties for an inlay hint. The
+        request's parameter is of type InlayHint, the response is of type InlayHint
+        or a Thenable that resolves to such.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("inlayHint/resolve", params)
+
+    async def shutdown_request(self, params: None) -> None:
+        """Make a ``shutdown`` request.
+
+        A shutdown request is sent from the client to the server.
+
+        It is sent once when the client decides to shutdown the server. The
+        only notification that is sent after a shutdown request is the exit
+        event.
+        """
+        return await self.lsp.send_request_async("shutdown", params)
+
+    async def text_document_code_action_request(self, params: CodeActionParams) -> typing.Optional[typing.List[typing.Union[lsprotocol.types.Command, lsprotocol.types.CodeAction]]]:
+        """Make a ``textDocument/codeAction`` request.
+
+        A request to provide commands for the given text document and range.
+        """
+        return await self.lsp.send_request_async("textDocument/codeAction", params)
+
+    async def text_document_code_lens_request(self, params: CodeLensParams) -> typing.Optional[typing.List[lsprotocol.types.CodeLens]]:
+        """Make a ``textDocument/codeLens`` request.
+
+        A request to provide code lens for the given text document.
+        """
+        return await self.lsp.send_request_async("textDocument/codeLens", params)
+
+    async def text_document_color_presentation_request(self, params: ColorPresentationParams) -> typing.List[lsprotocol.types.ColorPresentation]:
+        """Make a ``textDocument/colorPresentation`` request.
+
+        A request to list all presentation for a color.
+
+        The request's parameter is of type ColorPresentationParams the
+        response is of type ColorInformation[] or a Thenable that resolves
+        to such.
+        """
+        return await self.lsp.send_request_async("textDocument/colorPresentation", params)
+
+    async def text_document_completion_request(self, params: CompletionParams) -> typing.Union[typing.List[lsprotocol.types.CompletionItem], lsprotocol.types.CompletionList, None]:
+        """Make a ``textDocument/completion`` request.
+
+        Request to request completion at a given text document position. The
+        request's parameter is of type TextDocumentPosition the response is of type
+        CompletionItem[] or CompletionList or a Thenable that resolves to such.
+
+        The request can delay the computation of the
+        [`detail`](#CompletionItem.detail) and
+        [`documentation`](#CompletionItem.documentation) properties to the
+        `completionItem/resolve` request. However, properties that are
+        needed for the initial sorting and filtering, like `sortText`,
+        `filterText`, `insertText`, and `textEdit`, must not be changed
+        during resolve.
+        """
+        return await self.lsp.send_request_async("textDocument/completion", params)
+
+    async def text_document_declaration_request(self, params: DeclarationParams) -> typing.Union[lsprotocol.types.Location, typing.List[lsprotocol.types.Location], typing.List[lsprotocol.types.LocationLink], None]:
+        """Make a ``textDocument/declaration`` request.
+
+        A request to resolve the type definition locations of a symbol at a
+        given text document position.
+
+        The request's parameter is of type [TextDocumentPositionParams]
+        (#TextDocumentPositionParams) the response is of type Declaration or
+        a typed array of DeclarationLink or a Thenable that resolves to
+        such.
+        """
+        return await self.lsp.send_request_async("textDocument/declaration", params)
+
+    async def text_document_definition_request(self, params: DefinitionParams) -> typing.Union[lsprotocol.types.Location, typing.List[lsprotocol.types.Location], typing.List[lsprotocol.types.LocationLink], None]:
+        """Make a ``textDocument/definition`` request.
+
+        A request to resolve the definition location of a symbol at a given text
+        document position.
+
+        The request's parameter is of type [TextDocumentPosition]
+        (#TextDocumentPosition) the response is of either type Definition or
+        a typed array of DefinitionLink or a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("textDocument/definition", params)
+
+    async def text_document_diagnostic_request(self, params: DocumentDiagnosticParams) -> typing.Union[lsprotocol.types.RelatedFullDocumentDiagnosticReport, lsprotocol.types.RelatedUnchangedDocumentDiagnosticReport]:
+        """Make a ``textDocument/diagnostic`` request.
+
+        The document diagnostic request definition.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("textDocument/diagnostic", params)
+
+    async def text_document_document_color_request(self, params: DocumentColorParams) -> typing.List[lsprotocol.types.ColorInformation]:
+        """Make a ``textDocument/documentColor`` request.
+
+        A request to list all color symbols found in a given text document.
+
+        The request's parameter is of type DocumentColorParams the response
+        is of type ColorInformation[] or a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("textDocument/documentColor", params)
+
+    async def text_document_document_highlight_request(self, params: DocumentHighlightParams) -> typing.Optional[typing.List[lsprotocol.types.DocumentHighlight]]:
+        """Make a ``textDocument/documentHighlight`` request.
+
+        Request to resolve a DocumentHighlight for a given text document
+        position.
+
+        The request's parameter is of type [TextDocumentPosition]
+        (#TextDocumentPosition) the request response is of type
+        [DocumentHighlight[]] (#DocumentHighlight) or a Thenable that
+        resolves to such.
+        """
+        return await self.lsp.send_request_async("textDocument/documentHighlight", params)
+
+    async def text_document_document_link_request(self, params: DocumentLinkParams) -> typing.Optional[typing.List[lsprotocol.types.DocumentLink]]:
+        """Make a ``textDocument/documentLink`` request.
+
+        A request to provide document links.
+        """
+        return await self.lsp.send_request_async("textDocument/documentLink", params)
+
+    async def text_document_document_symbol_request(self, params: DocumentSymbolParams) -> typing.Union[typing.List[lsprotocol.types.SymbolInformation], typing.List[lsprotocol.types.DocumentSymbol], None]:
+        """Make a ``textDocument/documentSymbol`` request.
+
+        A request to list all symbols found in a given text document.
+
+        The request's parameter is of type TextDocumentIdentifier the
+        response is of type SymbolInformation[] or a Thenable that resolves
+        to such.
+        """
+        return await self.lsp.send_request_async("textDocument/documentSymbol", params)
+
+    async def text_document_folding_range_request(self, params: FoldingRangeParams) -> typing.Optional[typing.List[lsprotocol.types.FoldingRange]]:
+        """Make a ``textDocument/foldingRange`` request.
+
+        A request to provide folding ranges in a document.
+
+        The request's parameter is of type FoldingRangeParams, the response
+        is of type FoldingRangeList or a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("textDocument/foldingRange", params)
+
+    async def text_document_formatting_request(self, params: DocumentFormattingParams) -> typing.Optional[typing.List[lsprotocol.types.TextEdit]]:
+        """Make a ``textDocument/formatting`` request.
+
+        A request to to format a whole document.
+        """
+        return await self.lsp.send_request_async("textDocument/formatting", params)
+
+    async def text_document_hover_request(self, params: HoverParams) -> typing.Optional[lsprotocol.types.Hover]:
+        """Make a ``textDocument/hover`` request.
+
+        Request to request hover information at a given text document position.
+
+        The request's parameter is of type TextDocumentPosition the response
+        is of type Hover or a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("textDocument/hover", params)
+
+    async def text_document_implementation_request(self, params: ImplementationParams) -> typing.Union[lsprotocol.types.Location, typing.List[lsprotocol.types.Location], typing.List[lsprotocol.types.LocationLink], None]:
+        """Make a ``textDocument/implementation`` request.
+
+        A request to resolve the implementation locations of a symbol at a given
+        text document position.
+
+        The request's parameter is of type [TextDocumentPositionParams]
+        (#TextDocumentPositionParams) the response is of type Definition or
+        a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("textDocument/implementation", params)
+
+    async def text_document_inlay_hint_request(self, params: InlayHintParams) -> typing.Optional[typing.List[lsprotocol.types.InlayHint]]:
+        """Make a ``textDocument/inlayHint`` request.
+
+        A request to provide inlay hints in a document. The request's parameter
+        is of type InlayHintsParams, the response is of type.
+
+        [InlayHint[]](#InlayHint[]) or a Thenable that resolves to such.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("textDocument/inlayHint", params)
+
+    async def text_document_inline_value_request(self, params: InlineValueParams) -> typing.Optional[typing.List[typing.Union[lsprotocol.types.InlineValueText, lsprotocol.types.InlineValueVariableLookup, lsprotocol.types.InlineValueEvaluatableExpression]]]:
+        """Make a ``textDocument/inlineValue`` request.
+
+        A request to provide inline values in a document. The request's
+        parameter is of type InlineValueParams, the response is of type.
+
+        [InlineValue[]](#InlineValue[]) or a Thenable that resolves to such.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("textDocument/inlineValue", params)
+
+    async def text_document_linked_editing_range_request(self, params: LinkedEditingRangeParams) -> typing.Optional[lsprotocol.types.LinkedEditingRanges]:
+        """Make a ``textDocument/linkedEditingRange`` request.
+
+        A request to provide ranges that can be edited together.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("textDocument/linkedEditingRange", params)
+
+    async def text_document_moniker_request(self, params: MonikerParams) -> typing.Optional[typing.List[lsprotocol.types.Moniker]]:
+        """Make a ``textDocument/moniker`` request.
+
+        A request to get the moniker of a symbol at a given text document
+        position.
+
+        The request parameter is of type TextDocumentPositionParams. The
+        response is of type [Moniker[]](#Moniker[]) or `null`.
+        """
+        return await self.lsp.send_request_async("textDocument/moniker", params)
+
+    async def text_document_on_type_formatting_request(self, params: DocumentOnTypeFormattingParams) -> typing.Optional[typing.List[lsprotocol.types.TextEdit]]:
+        """Make a ``textDocument/onTypeFormatting`` request.
+
+        A request to format a document on type.
+        """
+        return await self.lsp.send_request_async("textDocument/onTypeFormatting", params)
+
+    async def text_document_prepare_call_hierarchy_request(self, params: CallHierarchyPrepareParams) -> typing.Optional[typing.List[lsprotocol.types.CallHierarchyItem]]:
+        """Make a ``textDocument/prepareCallHierarchy`` request.
+
+        A request to result a `CallHierarchyItem` in a document at a given
+        position. Can be used as an input to an incoming or outgoing call
+        hierarchy.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("textDocument/prepareCallHierarchy", params)
+
+    async def text_document_prepare_rename_request(self, params: PrepareRenameParams) -> typing.Union[lsprotocol.types.Range, lsprotocol.types.PrepareRenameResult_Type1, lsprotocol.types.PrepareRenameResult_Type2, None]:
+        """Make a ``textDocument/prepareRename`` request.
+
+        A request to test and perform the setup necessary for a rename.
+
+        @since 3.16 - support for default behavior
+        """
+        return await self.lsp.send_request_async("textDocument/prepareRename", params)
+
+    async def text_document_prepare_type_hierarchy_request(self, params: TypeHierarchyPrepareParams) -> typing.Optional[typing.List[lsprotocol.types.TypeHierarchyItem]]:
+        """Make a ``textDocument/prepareTypeHierarchy`` request.
+
+        A request to result a `TypeHierarchyItem` in a document at a given
+        position. Can be used as an input to a subtypes or supertypes type
+        hierarchy.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("textDocument/prepareTypeHierarchy", params)
+
+    async def text_document_range_formatting_request(self, params: DocumentRangeFormattingParams) -> typing.Optional[typing.List[lsprotocol.types.TextEdit]]:
+        """Make a ``textDocument/rangeFormatting`` request.
+
+        A request to to format a range in a document.
+        """
+        return await self.lsp.send_request_async("textDocument/rangeFormatting", params)
+
+    async def text_document_references_request(self, params: ReferenceParams) -> typing.Optional[typing.List[lsprotocol.types.Location]]:
+        """Make a ``textDocument/references`` request.
+
+        A request to resolve project-wide references for the symbol denoted by
+        the given text document position.
+
+        The request's parameter is of type ReferenceParams the response is
+        of type Location[] or a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("textDocument/references", params)
+
+    async def text_document_rename_request(self, params: RenameParams) -> typing.Optional[lsprotocol.types.WorkspaceEdit]:
+        """Make a ``textDocument/rename`` request.
+
+        A request to rename a symbol.
+        """
+        return await self.lsp.send_request_async("textDocument/rename", params)
+
+    async def text_document_selection_range_request(self, params: SelectionRangeParams) -> typing.Optional[typing.List[lsprotocol.types.SelectionRange]]:
+        """Make a ``textDocument/selectionRange`` request.
+
+        A request to provide selection ranges in a document.
+
+        The request's parameter is of type SelectionRangeParams, the
+        response is of type [SelectionRange[]](#SelectionRange[]) or a
+        Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("textDocument/selectionRange", params)
+
+    async def text_document_semantic_tokens_full_request(self, params: SemanticTokensParams) -> typing.Optional[lsprotocol.types.SemanticTokens]:
+        """Make a ``textDocument/semanticTokens/full`` request.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("textDocument/semanticTokens/full", params)
+
+    async def text_document_semantic_tokens_full_delta_request(self, params: SemanticTokensDeltaParams) -> typing.Union[lsprotocol.types.SemanticTokens, lsprotocol.types.SemanticTokensDelta, None]:
+        """Make a ``textDocument/semanticTokens/full/delta`` request.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("textDocument/semanticTokens/full/delta", params)
+
+    async def text_document_semantic_tokens_range_request(self, params: SemanticTokensRangeParams) -> typing.Optional[lsprotocol.types.SemanticTokens]:
+        """Make a ``textDocument/semanticTokens/range`` request.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("textDocument/semanticTokens/range", params)
+
+    async def text_document_signature_help_request(self, params: SignatureHelpParams) -> typing.Optional[lsprotocol.types.SignatureHelp]:
+        """Make a ``textDocument/signatureHelp`` request.
+
+
+        """
+        return await self.lsp.send_request_async("textDocument/signatureHelp", params)
+
+    async def text_document_type_definition_request(self, params: TypeDefinitionParams) -> typing.Union[lsprotocol.types.Location, typing.List[lsprotocol.types.Location], typing.List[lsprotocol.types.LocationLink], None]:
+        """Make a ``textDocument/typeDefinition`` request.
+
+        A request to resolve the type definition locations of a symbol at a
+        given text document position.
+
+        The request's parameter is of type [TextDocumentPositionParams]
+        (#TextDocumentPositionParams) the response is of type Definition or
+        a Thenable that resolves to such.
+        """
+        return await self.lsp.send_request_async("textDocument/typeDefinition", params)
+
+    async def text_document_will_save_wait_until_request(self, params: WillSaveTextDocumentParams) -> typing.Optional[typing.List[lsprotocol.types.TextEdit]]:
+        """Make a ``textDocument/willSaveWaitUntil`` request.
+
+        A document will save request is sent from the client to the server
+        before the document is actually saved.
+
+        The request can return an array of TextEdits which will be applied
+        to the text document before it is saved. Please note that clients
+        might drop results if computing the text edits took too long or if a
+        server constantly fails on this request. This is done to keep the
+        save fast and reliable.
+        """
+        return await self.lsp.send_request_async("textDocument/willSaveWaitUntil", params)
+
+    async def type_hierarchy_subtypes_request(self, params: TypeHierarchySubtypesParams) -> typing.Optional[typing.List[lsprotocol.types.TypeHierarchyItem]]:
+        """Make a ``typeHierarchy/subtypes`` request.
+
+        A request to resolve the subtypes for a given `TypeHierarchyItem`.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("typeHierarchy/subtypes", params)
+
+    async def type_hierarchy_supertypes_request(self, params: TypeHierarchySupertypesParams) -> typing.Optional[typing.List[lsprotocol.types.TypeHierarchyItem]]:
+        """Make a ``typeHierarchy/supertypes`` request.
+
+        A request to resolve the supertypes for a given `TypeHierarchyItem`.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("typeHierarchy/supertypes", params)
+
+    async def workspace_diagnostic_request(self, params: WorkspaceDiagnosticParams) -> lsprotocol.types.WorkspaceDiagnosticReport:
+        """Make a ``workspace/diagnostic`` request.
+
+        The workspace diagnostic request definition.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("workspace/diagnostic", params)
+
+    async def workspace_diagnostic_refresh_request(self, params: None) -> None:
+        """Make a ``workspace/diagnostic/refresh`` request.
+
+        The diagnostic refresh request definition.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("workspace/diagnostic/refresh", params)
+
+    async def workspace_execute_command_request(self, params: ExecuteCommandParams) -> typing.Union[object, typing.List[typing.Union[object, typing.List[lsprotocol.types.LSPAny], str, int, float, bool, None]], str, int, float, bool, None]:
+        """Make a ``workspace/executeCommand`` request.
+
+        A request send from the client to the server to execute a command.
+
+        The request might return a workspace edit which the client will
+        apply to the workspace.
+        """
+        return await self.lsp.send_request_async("workspace/executeCommand", params)
+
+    async def workspace_inlay_hint_refresh_request(self, params: None) -> None:
+        """Make a ``workspace/inlayHint/refresh`` request.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("workspace/inlayHint/refresh", params)
+
+    async def workspace_inline_value_refresh_request(self, params: None) -> None:
+        """Make a ``workspace/inlineValue/refresh`` request.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("workspace/inlineValue/refresh", params)
+
+    async def workspace_semantic_tokens_refresh_request(self, params: None) -> None:
+        """Make a ``workspace/semanticTokens/refresh`` request.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("workspace/semanticTokens/refresh", params)
+
+    async def workspace_symbol_request(self, params: WorkspaceSymbolParams) -> typing.Union[typing.List[lsprotocol.types.SymbolInformation], typing.List[lsprotocol.types.WorkspaceSymbol], None]:
+        """Make a ``workspace/symbol`` request.
+
+        A request to list project-wide symbols matching the query string given
+        by the WorkspaceSymbolParams. The response is of type SymbolInformation[]
+        or a Thenable that resolves to such.
+
+        @since 3.17.0 - support for WorkspaceSymbol in the returned data. Clients
+         need to advertise support for WorkspaceSymbols via the client capability
+         `workspace.symbol.resolveSupport`.
+        """
+        return await self.lsp.send_request_async("workspace/symbol", params)
+
+    async def workspace_symbol_resolve_request(self, params: WorkspaceSymbol) -> lsprotocol.types.WorkspaceSymbol:
+        """Make a ``workspaceSymbol/resolve`` request.
+
+        A request to resolve the range inside the workspace symbol's location.
+
+        @since 3.17.0
+        """
+        return await self.lsp.send_request_async("workspaceSymbol/resolve", params)
+
+    async def workspace_will_create_files_request(self, params: CreateFilesParams) -> typing.Optional[lsprotocol.types.WorkspaceEdit]:
+        """Make a ``workspace/willCreateFiles`` request.
+
+        The will create files request is sent from the client to the server
+        before files are actually created as long as the creation is triggered from
+        within the client.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("workspace/willCreateFiles", params)
+
+    async def workspace_will_delete_files_request(self, params: DeleteFilesParams) -> typing.Optional[lsprotocol.types.WorkspaceEdit]:
+        """Make a ``workspace/willDeleteFiles`` request.
+
+        The did delete files notification is sent from the client to the server
+        when files were deleted from within the client.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("workspace/willDeleteFiles", params)
+
+    async def workspace_will_rename_files_request(self, params: RenameFilesParams) -> typing.Optional[lsprotocol.types.WorkspaceEdit]:
+        """Make a ``workspace/willRenameFiles`` request.
+
+        The will rename files request is sent from the client to the server
+        before files are actually renamed as long as the rename is triggered from
+        within the client.
+
+        @since 3.16.0
+        """
+        return await self.lsp.send_request_async("workspace/willRenameFiles", params)
+
+    def notify_cancel_request(self, params: CancelParams) -> None:
+        """Send a ``$/cancelRequest`` notification.
+
+
+        """
+        self.lsp.notify("$/cancelRequest", params)
+
+    def notify_exit(self, params: None) -> None:
+        """Send a ``exit`` notification.
+
+        The exit event is sent from the client to the server to ask the server
+        to exit its process.
+        """
+        self.lsp.notify("exit", params)
+
+    def notify_initialized(self, params: InitializedParams) -> None:
+        """Send a ``initialized`` notification.
+
+        The initialized notification is sent from the client to the server after
+        the client is fully initialized and the server is allowed to send requests
+        from the server to the client.
+        """
+        self.lsp.notify("initialized", params)
+
+    def notify_notebook_document_did_change(self, params: DidChangeNotebookDocumentParams) -> None:
+        """Send a ``notebookDocument/didChange`` notification.
+
+
+        """
+        self.lsp.notify("notebookDocument/didChange", params)
+
+    def notify_notebook_document_did_close(self, params: DidCloseNotebookDocumentParams) -> None:
+        """Send a ``notebookDocument/didClose`` notification.
+
+        A notification sent when a notebook closes.
+
+        @since 3.17.0
+        """
+        self.lsp.notify("notebookDocument/didClose", params)
+
+    def notify_notebook_document_did_open(self, params: DidOpenNotebookDocumentParams) -> None:
+        """Send a ``notebookDocument/didOpen`` notification.
+
+        A notification sent when a notebook opens.
+
+        @since 3.17.0
+        """
+        self.lsp.notify("notebookDocument/didOpen", params)
+
+    def notify_notebook_document_did_save(self, params: DidSaveNotebookDocumentParams) -> None:
+        """Send a ``notebookDocument/didSave`` notification.
+
+        A notification sent when a notebook document is saved.
+
+        @since 3.17.0
+        """
+        self.lsp.notify("notebookDocument/didSave", params)
+
+    def notify_progress(self, params: ProgressParams) -> None:
+        """Send a ``$/progress`` notification.
+
+
+        """
+        self.lsp.notify("$/progress", params)
+
+    def notify_set_trace(self, params: SetTraceParams) -> None:
+        """Send a ``$/setTrace`` notification.
+
+
+        """
+        self.lsp.notify("$/setTrace", params)
+
+    def notify_text_document_did_change(self, params: DidChangeTextDocumentParams) -> None:
+        """Send a ``textDocument/didChange`` notification.
+
+        The document change notification is sent from the client to the server
+        to signal changes to a text document.
+        """
+        self.lsp.notify("textDocument/didChange", params)
+
+    def notify_text_document_did_close(self, params: DidCloseTextDocumentParams) -> None:
+        """Send a ``textDocument/didClose`` notification.
+
+        The document close notification is sent from the client to the server
+        when the document got closed in the client.
+
+        The document's truth now exists where the document's uri points to
+        (e.g. if the document's uri is a file uri the truth now exists on
+        disk). As with the open notification the close notification is about
+        managing the document's content. Receiving a close notification
+        doesn't mean that the document was open in an editor before. A close
+        notification requires a previous open notification to be sent.
+        """
+        self.lsp.notify("textDocument/didClose", params)
+
+    def notify_text_document_did_open(self, params: DidOpenTextDocumentParams) -> None:
+        """Send a ``textDocument/didOpen`` notification.
+
+        The document open notification is sent from the client to the server to
+        signal newly opened text documents.
+
+        The document's truth is now managed by the client and the server
+        must not try to read the document's truth using the document's uri.
+        Open in this sense means it is managed by the client. It doesn't
+        necessarily mean that its content is presented in an editor. An open
+        notification must not be sent more than once without a corresponding
+        close notification send before. This means open and close
+        notification must be balanced and the max open count is one.
+        """
+        self.lsp.notify("textDocument/didOpen", params)
+
+    def notify_text_document_did_save(self, params: DidSaveTextDocumentParams) -> None:
+        """Send a ``textDocument/didSave`` notification.
+
+        The document save notification is sent from the client to the server
+        when the document got saved in the client.
+        """
+        self.lsp.notify("textDocument/didSave", params)
+
+    def notify_text_document_will_save(self, params: WillSaveTextDocumentParams) -> None:
+        """Send a ``textDocument/willSave`` notification.
+
+        A document will save notification is sent from the client to the server
+        before the document is actually saved.
+        """
+        self.lsp.notify("textDocument/willSave", params)
+
+    def notify_window_work_done_progress_cancel(self, params: WorkDoneProgressCancelParams) -> None:
+        """Send a ``window/workDoneProgress/cancel`` notification.
+
+        The `window/workDoneProgress/cancel` notification is sent from  the
+        client to the server to cancel a progress initiated on the server side.
+        """
+        self.lsp.notify("window/workDoneProgress/cancel", params)
+
+    def notify_workspace_did_change_configuration(self, params: DidChangeConfigurationParams) -> None:
+        """Send a ``workspace/didChangeConfiguration`` notification.
+
+        The configuration change notification is sent from the client to the
+        server when the client's configuration has changed.
+
+        The notification contains the changed configuration as defined by
+        the language client.
+        """
+        self.lsp.notify("workspace/didChangeConfiguration", params)
+
+    def notify_workspace_did_change_watched_files(self, params: DidChangeWatchedFilesParams) -> None:
+        """Send a ``workspace/didChangeWatchedFiles`` notification.
+
+        The watched files notification is sent from the client to the server
+        when the client detects changes to file watched by the language client.
+        """
+        self.lsp.notify("workspace/didChangeWatchedFiles", params)
+
+    def notify_workspace_did_change_workspace_folders(self, params: DidChangeWorkspaceFoldersParams) -> None:
+        """Send a ``workspace/didChangeWorkspaceFolders`` notification.
+
+        The `workspace/didChangeWorkspaceFolders` notification is sent from the
+        client to the server when the workspace folder configuration changes.
+        """
+        self.lsp.notify("workspace/didChangeWorkspaceFolders", params)
+
+    def notify_workspace_did_create_files(self, params: CreateFilesParams) -> None:
+        """Send a ``workspace/didCreateFiles`` notification.
+
+        The did create files notification is sent from the client to the server
+        when files were created from within the client.
+
+        @since 3.16.0
+        """
+        self.lsp.notify("workspace/didCreateFiles", params)
+
+    def notify_workspace_did_delete_files(self, params: DeleteFilesParams) -> None:
+        """Send a ``workspace/didDeleteFiles`` notification.
+
+        The will delete files request is sent from the client to the server
+        before files are actually deleted as long as the deletion is triggered from
+        within the client.
+
+        @since 3.16.0
+        """
+        self.lsp.notify("workspace/didDeleteFiles", params)
+
+    def notify_workspace_did_rename_files(self, params: RenameFilesParams) -> None:
+        """Send a ``workspace/didRenameFiles`` notification.
+
+        The did rename files notification is sent from the client to the server
+        when files were renamed from within the client.
+
+        @since 3.16.0
+        """
+        self.lsp.notify("workspace/didRenameFiles", params)

--- a/lib/pytest-lsp/pytest_lsp/plugin.py
+++ b/lib/pytest-lsp/pytest_lsp/plugin.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import textwrap
 import threading
+import time
 from typing import Any
 from typing import Callable
 from typing import Iterable
@@ -16,14 +17,15 @@ from typing import Union
 
 import pytest
 import pytest_asyncio
-from pygls.lsp.methods import EXIT
-from pygls.lsp.methods import INITIALIZE
-from pygls.lsp.methods import INITIALIZED
-from pygls.lsp.methods import SHUTDOWN
-from pygls.lsp.types import ClientCapabilities
-from pygls.lsp.types import InitializeParams
+from lsprotocol.converters import get_converter
+from lsprotocol.types import ClientCapabilities
+from lsprotocol.types import LSPAny
+from lsprotocol.types import InitializeParams
+from lsprotocol.types import InitializedParams
+from pygls.exceptions import JsonRpcInternalError
 
-from pytest_lsp.client import Client
+from pytest_lsp.client import LanguageClient
+from pytest_lsp.client import cancel_all_tasks
 from pytest_lsp.client import make_test_client
 
 if sys.version_info.minor < 9:
@@ -35,10 +37,27 @@ else:
 logger = logging.getLogger("client")
 
 
-if hasattr(pytest_asyncio, "fixture"):
-    make_fixture = pytest_asyncio.fixture
-else:
-    make_fixture = pytest.fixture
+def watch_server_process(
+    server: subprocess.Popen, stop: threading.Event, client: LanguageClient
+):
+    """Continously poll server process to see if it is still running."""
+    while True:
+        retcode = server.poll()
+
+        if stop.is_set():
+            break
+
+        if retcode is not None:
+
+            stderr = ""
+            if server.stderr is not None:
+                stderr = server.stderr.read().decode("utf8")
+
+            message = f"Server exited with return code: {retcode}\n{stderr}"
+            client._report_server_error(RuntimeError(message), RuntimeError)
+            break
+
+        time.sleep(0.1)
 
 
 class ClientServer:
@@ -46,17 +65,20 @@ class ClientServer:
 
     def __init__(
         self,
-        client: Client,
+        client: LanguageClient,
         server: subprocess.Popen,
         root_uri: str,
         client_capabilities: ClientCapabilities,
-        initialization_options: Optional[Any],
+        initialization_options: Optional[LSPAny],
     ):
 
         self._server = server
         """The process object running the server."""
 
+        control_loop = asyncio.get_running_loop()
+
         self.client = client
+        self.client._control_loop = control_loop
         """The client used to drive the test."""
 
         self.client_capabilities = client_capabilities
@@ -66,8 +88,17 @@ class ClientServer:
             name="Client Thread",
             target=self.client.start_io,
             args=(self._server.stdout, self._server.stdin),
+            daemon=True,
         )
-        self._client_thread.daemon = True
+
+        # Used to detect if the server crashes.
+        self._watchdog_stop = threading.Event()
+        self._watchdog_thread = threading.Thread(
+            name="Watchdog Thread",
+            target=watch_server_process,
+            args=(self._server, self._watchdog_stop, self.client),
+            daemon=True,
+        )
 
         self.initialization_options = initialization_options
         """The initialization options to pass to the server."""
@@ -76,38 +107,47 @@ class ClientServer:
         """The root uri to point the server at."""
 
     async def start(self):
+        self._watchdog_thread.start()
         self._client_thread.start()
 
         # Give the client some time to initialize
         while self.client.lsp.transport is None:
             await asyncio.sleep(0.1)
 
-        response = await self.client.lsp.send_request_async(
-            INITIALIZE,
+        response = await self.client.initialize_request(
             InitializeParams(
                 process_id=os.getpid(),
                 root_uri=self.root_uri,
                 capabilities=self.client_capabilities,
-                initialization_options=self.initialization_options or {},
+                initialization_options=self.initialization_options,
             ),
         )
 
-        assert "capabilities" in response
-        self.client.lsp.notify(INITIALIZED)
+        assert response.capabilities is not None
+        self.client.notify_initialized(InitializedParams())
 
         return response
 
     async def stop(self):
-        response = await self.client.lsp.send_request_async(SHUTDOWN)
-        assert response is None
 
-        self.client.lsp.notify(EXIT)
+        # Only attempt if there wasn't an error.
+        if self.client.error is None:
+            response = await self.client.shutdown_request(None)
+            assert response is None
+
+            self.client.notify_exit(None)
+        else:
+            self._server.terminate()
 
         self.client._stop_event.set()
+
         try:
             self.client.loop._signal_handlers.clear()
         except AttributeError:
             pass
+
+        self._watchdog_stop.set()
+        self._watchdog_thread.join()
 
         self._client_thread.join()
 
@@ -122,28 +162,40 @@ class ClientServerConfig:
         *,
         client: str = "",
         client_capabilities: Optional[ClientCapabilities] = None,
-        client_factory: Callable = make_test_client,
+        client_factory: Callable[..., LanguageClient] = make_test_client,
         initialization_options: Optional[Any] = None,
     ) -> None:
+        """
+        Parameters
+        ----------
+        server_command
+           The command to use to start the language server.
 
-        self.server_command: List[str] = server_command
-        """The command to use to start the language server."""
+        root_uri
+           The root uri to start the language server in
 
-        self.root_uri: str = root_uri
-        """The root uri to start the language server in"""
+        client
+           The name of the client profile to use
 
-        self.client: str = client
-        """The name of the client profile to use"""
+        client_capabilities
+           Use to use a specific set of client, capabilities.
+           Specifiying this will override ``client``.
 
-        self.client_capabilities: Optional[ClientCapabilities] = client_capabilities
-        """Use to use a specific set of client, capabilities. The setting overrides
-        ``client``."""
+        client_factory
+           Factory function to use when constructing the language client instance.
+           Defaults to :func:`pytest_lsp.make_test_client`
 
-        self.client_factory: Callable = client_factory
-        """The function to use to return a test client instance."""
+        initialization_options
+           The initialization options to pass to the server on start up.
 
+        """
+
+        self.server_command = server_command
+        self.root_uri = root_uri
+        self.client = client
+        self.client_capabilities = client_capabilities
+        self.client_factory = client_factory
         self.initialization_options = initialization_options
-        """The initialization options to pass to the server on start up."""
 
 
 def find_client_capabilities(client: str) -> ClientCapabilities:
@@ -168,28 +220,20 @@ def find_client_capabilities(client: str) -> ClientCapabilities:
     if not filename:
         raise ValueError(f"Unsupported client '{client}'")
 
-    return ClientCapabilities(**json.loads(filename.read_text()))
+    converter = get_converter()
+    capabilities = json.loads(filename.read_text())
+    return converter.structure(capabilities, ClientCapabilities)
 
 
 def make_client_server(config: ClientServerConfig) -> ClientServer:
     """Construct a new ``ClientServer`` instance."""
 
     server = subprocess.Popen(
-        config.server_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE
+        config.server_command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-
-    try:
-        # Timeout is arbitrary, because we'd also like to know if the server crashes
-        # in the future. But this is useful because if the server is going to crash
-        # it will most likely do it in the first few milliseconds of startup.
-        server.wait(timeout=0.1)
-    except subprocess.TimeoutExpired:
-        pass
-    finally:
-        if server.returncode is not None:
-            raise Exception(
-                f"{config.server_command} exited with exit code {server.returncode}"
-            )
 
     if config.client_capabilities:
         capabilities = config.client_capabilities
@@ -198,8 +242,10 @@ def make_client_server(config: ClientServerConfig) -> ClientServer:
     else:
         capabilities = ClientCapabilities()
 
+    client = config.client_factory(capabilities, config.root_uri)
+
     return ClientServer(
-        client=config.client_factory(capabilities, config.root_uri),
+        client=client,
         server=server,
         client_capabilities=capabilities,
         root_uri=config.root_uri,
@@ -209,10 +255,10 @@ def make_client_server(config: ClientServerConfig) -> ClientServer:
 
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
     """Add any captured log messages to the report."""
-    client: Optional[Client] = None
+    client: Optional[LanguageClient] = None
 
     for arg in item.funcargs.values():
-        if isinstance(arg, Client):
+        if isinstance(arg, LanguageClient):
             client = arg
             break
 
@@ -228,7 +274,8 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
         client._last_log_index = len(client.log_messages)
 
     messages = [
-        f"{textwrap.indent(m.message, levels[m.type - 1])}" for m in captured_messages
+        f"{textwrap.indent(m.message, levels[m.type.value - 1])}"
+        for m in captured_messages
     ]
 
     if len(messages) > 0:
@@ -248,7 +295,7 @@ def fixture(
     ids = [conf.client or f"client{idx}" for idx, conf in enumerate(config)]
 
     def wrapper(fn):
-        @make_fixture(params=config, ids=ids, **kwargs)
+        @pytest_asyncio.fixture(params=config, ids=ids, **kwargs)
         async def the_fixture(request):
 
             lsp = make_client_server(request.param)

--- a/lib/pytest-lsp/setup.cfg
+++ b/lib/pytest-lsp/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 platforms = any
 
 [options]

--- a/lib/pytest-lsp/setup.cfg
+++ b/lib/pytest-lsp/setup.cfg
@@ -2,41 +2,41 @@
 name = pytest-lsp
 version = 0.1.3
 description = Pytest plugin for end-to-end testing of language servers
-long_description = file:README.md 
+long_description = file:README.md
 long_description_content_type = text/markdown
 author = Alex Carney
 author_email = alcarneyme@gmail.com
 url = https://alcarney.github.io/lsp-devtools
-project_urls = 
+project_urls =
     Bug Tracker = https://github.com/alcarney/lsp-devtools/issues
     Source Code = https://github.com/alcarney/lsp-devtools
 license = MIT
-classifiers = 
+classifiers =
     Development Status :: 3 - Alpha
     License :: OSI Approved :: MIT License
     Framework :: Pytest
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-platforms = any 
+platforms = any
 
 [options]
 packages = find:
 include_package_data = True
-install_requires = 
+python_requires= >=3.7
+install_requires =
     appdirs
     importlib-resources; python_version<"3.9"
     pygls>=0.11.0,<1.0
     pytest
-    pytest-asyncio 
+    pytest-asyncio
 
 [options.extras_require]
-dev = black ; mypy ; flake8 ; pre-commit ; pytest-cov ; pytest-timeout ; tox ; types-appdirs 
+dev = black ; mypy ; flake8 ; pre-commit ; pytest-cov ; pytest-timeout ; tox ; types-appdirs
 
 [options.entry_points]
 pytest11 =

--- a/lib/pytest-lsp/setup.cfg
+++ b/lib/pytest-lsp/setup.cfg
@@ -31,7 +31,7 @@ python_requires= >=3.7
 install_requires =
     appdirs
     importlib-resources; python_version<"3.9"
-    pygls>=0.11.0,<1.0
+    pygls>=1.0.0
     pytest
     pytest-asyncio
 

--- a/lib/pytest-lsp/tests/servers/capabilities.py
+++ b/lib/pytest-lsp/tests/servers/capabilities.py
@@ -1,12 +1,13 @@
+from lsprotocol.converters import get_converter
 from pygls.server import LanguageServer
 
-
-server = LanguageServer()
+converter = get_converter()
+server = LanguageServer(name="capabilities-server", version="v1.0")
 
 
 @server.command("return.client.capabilities")
 def on_initialize(ls: LanguageServer, *args):
-    return ls.client_capabilities.dict(by_alias=False)
+    return ls.client_capabilities
 
 
 if __name__ == "__main__":

--- a/lib/pytest-lsp/tests/servers/completion_exit.py
+++ b/lib/pytest-lsp/tests/servers/completion_exit.py
@@ -1,0 +1,21 @@
+# A server that exits mid request.
+import sys
+
+from lsprotocol.types import TEXT_DOCUMENT_COMPLETION
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import CompletionParams
+from pygls.server import LanguageServer
+
+count = 0
+server = LanguageServer(name="completion-exit-server", version="v1.0")
+
+
+@server.feature(TEXT_DOCUMENT_COMPLETION)
+def on_complete(server: LanguageServer, params: CompletionParams):
+
+    count += 1
+    if count == 5:
+        sys.exit(0)
+
+    return [CompletionItem(label=f"{count}")]
+

--- a/lib/pytest-lsp/tests/servers/crash.py
+++ b/lib/pytest-lsp/tests/servers/crash.py
@@ -1,0 +1,14 @@
+# Not a server, used to simulate the case where the server crashes before
+# it can boot.
+
+def f(x):
+    return x / 0
+
+def g(x):
+    return f(x) * f(x)
+
+def h(x):
+    return g(x) - f(x)
+
+
+h(2)

--- a/lib/pytest-lsp/tests/servers/hello.py
+++ b/lib/pytest-lsp/tests/servers/hello.py
@@ -1,0 +1,2 @@
+# Not actually a server, but a script that prints hello world.
+print("Hello, world!")

--- a/lib/pytest-lsp/tests/servers/invalid_json.py
+++ b/lib/pytest-lsp/tests/servers/invalid_json.py
@@ -1,0 +1,36 @@
+# A server that returns a message that cannot be parsed as JSON.
+import json
+
+from lsprotocol.types import TEXT_DOCUMENT_COMPLETION
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import CompletionParams
+from pygls.protocol import default_converter
+from pygls.server import LanguageServer
+
+
+server = LanguageServer(name="completion-exit-server", version="v1.0")
+
+
+def bad_send_data(data):
+    """Sends data to the client in a way that cannot be parsed."""
+    if not data:
+        return
+
+    self = server.lsp
+    body = json.dumps(data, default=self._serialize_message)
+    body = body.replace('"', "'").encode(self.CHARSET)
+    header = (
+        f'Content-Length: {len(body)}\r\n'
+        f'Content-Type: {self.CONTENT_TYPE}; charset={self.CHARSET}\r\n\r\n'
+    ).encode(self.CHARSET)
+
+    self.transport.write(header + body)
+
+
+@server.feature(TEXT_DOCUMENT_COMPLETION)
+def on_complete(server: LanguageServer, params: CompletionParams):
+    server.lsp._send_data = bad_send_data
+    return [CompletionItem(label=f"item-one")]
+
+
+server.start_io()

--- a/lib/pytest-lsp/tests/servers/methods.py
+++ b/lib/pytest-lsp/tests/servers/methods.py
@@ -1,10 +1,35 @@
 """Used for testing client's handling of return types."""
-from pygls.lsp.methods import *
-from pygls.lsp.types import *
+import logging
+
+from lsprotocol.types import COMPLETION_ITEM_RESOLVE
+from lsprotocol.types import TEXT_DOCUMENT_COMPLETION
+from lsprotocol.types import TEXT_DOCUMENT_DEFINITION
+from lsprotocol.types import TEXT_DOCUMENT_DOCUMENT_LINK
+from lsprotocol.types import TEXT_DOCUMENT_DOCUMENT_SYMBOL
+from lsprotocol.types import TEXT_DOCUMENT_HOVER
+from lsprotocol.types import TEXT_DOCUMENT_IMPLEMENTATION
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import CompletionList
+from lsprotocol.types import CompletionParams
+from lsprotocol.types import DefinitionParams
+from lsprotocol.types import DocumentLink
+from lsprotocol.types import DocumentLinkParams
+from lsprotocol.types import DocumentSymbol
+from lsprotocol.types import DocumentSymbolParams
+from lsprotocol.types import Hover
+from lsprotocol.types import HoverParams
+from lsprotocol.types import ImplementationParams
+from lsprotocol.types import Location
+from lsprotocol.types import LocationLink
+from lsprotocol.types import MarkupContent
+from lsprotocol.types import MarkupKind
+from lsprotocol.types import Position
+from lsprotocol.types import Range
+from lsprotocol.types import SymbolInformation
+from lsprotocol.types import SymbolKind
 from pygls.server import LanguageServer
 
-
-server = LanguageServer()
+server = LanguageServer(name="methods-server", version="v1.0")
 
 
 def arange(spec: str) -> Range:
@@ -19,7 +44,7 @@ def arange(spec: str) -> Range:
     )
 
 
-@server.feature(COMPLETION)
+@server.feature(TEXT_DOCUMENT_COMPLETION)
 def on_complete(ls: LanguageServer, params: CompletionParams):
 
     line = params.position.line
@@ -42,7 +67,7 @@ def on_complete_resolve(ls: LanguageServer, item: CompletionItem):
     return item
 
 
-@server.feature(DEFINITION)
+@server.feature(TEXT_DOCUMENT_DEFINITION)
 def on_definition(ls: LanguageServer, params: DefinitionParams):
 
     line = params.position.line
@@ -68,7 +93,7 @@ def on_definition(ls: LanguageServer, params: DefinitionParams):
     ]
 
 
-@server.feature(DOCUMENT_LINK)
+@server.feature(TEXT_DOCUMENT_DOCUMENT_LINK)
 def on_document_link(ls: LanguageServer, params: DocumentLinkParams):
 
     doc = params.text_document.uri
@@ -83,7 +108,7 @@ def on_document_link(ls: LanguageServer, params: DocumentLinkParams):
         ]
 
 
-@server.feature(DOCUMENT_SYMBOL)
+@server.feature(TEXT_DOCUMENT_DOCUMENT_SYMBOL)
 def on_document_symbol(ls: LanguageServer, params: DocumentSymbolParams):
 
     doc = params.text_document.uri
@@ -119,7 +144,7 @@ def on_document_symbol(ls: LanguageServer, params: DocumentSymbolParams):
     ]
 
 
-@server.feature(HOVER)
+@server.feature(TEXT_DOCUMENT_HOVER)
 def on_hover(ls: LanguageServer, params: HoverParams):
 
     line = params.position.line
@@ -132,7 +157,7 @@ def on_hover(ls: LanguageServer, params: HoverParams):
     )
 
 
-@server.feature(IMPLEMENTATION)
+@server.feature(TEXT_DOCUMENT_IMPLEMENTATION)
 def on_implementation(ls: LanguageServer, params: ImplementationParams):
 
     line = params.position.line

--- a/lib/pytest-lsp/tests/servers/methods.py
+++ b/lib/pytest-lsp/tests/servers/methods.py
@@ -9,9 +9,9 @@ server = LanguageServer()
 
 def arange(spec: str) -> Range:
 
-    start_line, start_char, end_line, end_char = [
+    start_line, start_char, end_line, end_char = (
         int(i) for item in spec.split("-") for i in item.split(":")
-    ]
+    )
 
     return Range(
         start=Position(line=start_line, character=start_char),

--- a/lib/pytest-lsp/tests/test_client.py
+++ b/lib/pytest-lsp/tests/test_client.py
@@ -61,13 +61,16 @@ async def client(client_):
         f"""
 import json
 import pytest
+from lsprotocol.types import ExecuteCommandParams
 
 @pytest.mark.asyncio
 async def test_capabilities(client):
-    actual = await client.execute_command_request("return.client.capabilities")
+    actual = await client.workspace_execute_command_request(
+        ExecuteCommandParams(command="return.client.capabilities")
+    )
     assert actual == json.loads('{expected}')
     """
     )
 
-    results = pytester.runpytest()
+    results = pytester.runpytest('-vv')
     results.assert_outcomes(passed=1)

--- a/lib/pytest-lsp/tests/test_client_methods.py
+++ b/lib/pytest-lsp/tests/test_client_methods.py
@@ -15,9 +15,9 @@ TEST_URI = f"{ROOT_URI}/text.txt"
 
 def arange(spec: str) -> Range:
 
-    start_line, start_char, end_line, end_char = [
+    start_line, start_char, end_line, end_char = (
         int(i) for item in spec.split("-") for i in item.split(":")
-    ]
+    )
 
     return Range(
         start=Position(line=start_line, character=start_char),

--- a/lib/pytest-lsp/tests/test_client_methods.py
+++ b/lib/pytest-lsp/tests/test_client_methods.py
@@ -4,12 +4,25 @@ import sys
 
 import pygls.uris as uri
 import pytest
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import CompletionList
+from lsprotocol.types import DocumentLink
+from lsprotocol.types import DocumentSymbol
+from lsprotocol.types import Hover
+from lsprotocol.types import Location
+from lsprotocol.types import LocationLink
+from lsprotocol.types import MarkupContent
+from lsprotocol.types import MarkupKind
+from lsprotocol.types import Position
+from lsprotocol.types import Range
+from lsprotocol.types import SymbolInformation
+from lsprotocol.types import SymbolKind
+
 import pytest_lsp
-from pygls.lsp.types import *
-from pytest_lsp import Client
+from pytest_lsp import LanguageClient
 from pytest_lsp import ClientServerConfig
 
-ROOT_URI = uri.from_fs_path(str(pathlib.Path(__file__).parent))
+ROOT_URI: str = uri.from_fs_path(str(pathlib.Path(__file__).parent))  # type: ignore
 TEST_URI = f"{ROOT_URI}/text.txt"
 
 
@@ -66,19 +79,18 @@ async def client(client_):
         ),
     ],
 )
-async def test_client_completion(client: Client, line: int, expected):
+async def test_client_completion(client: LanguageClient, line: int, expected):
     """Ensure that the client can handle completion responses correctly"""
 
     response = await client.completion_request(TEST_URI, line, 0)
-
     assert response == expected
 
 
-async def test_client_completion_resolve(client: Client):
+async def test_client_completion_resolve(client: LanguageClient):
     """Ensure that the client can handle completion resolve responses correctly"""
 
     item = CompletionItem(label="item-one")
-    response = await client.completion_resolve_request(item)
+    response = await client.completion_item_resolve_request(item)
 
     assert response.documentation == "This is documented"
 
@@ -107,11 +119,11 @@ async def test_client_completion_resolve(client: Client):
         ),
     ],
 )
-async def test_client_definition(client: Client, line: int, expected):
+async def test_client_definition(client: LanguageClient, line: int, expected):
     """Ensure that the client can handle definition responses correctly"""
 
     response = await client.definition_request(
-        TEST_URI, Position(line=line, character=0)
+        TEST_URI, line=line, character=0
     )
 
     assert response == expected
@@ -130,7 +142,7 @@ async def test_client_definition(client: Client, line: int, expected):
         ),
     ],
 )
-async def test_client_document_link(client: Client, uri: str, expected):
+async def test_client_document_link(client: LanguageClient, uri: str, expected):
     """Ensure that the client can handle document link responses correctly"""
 
     response = await client.document_link_request(uri)
@@ -173,7 +185,7 @@ async def test_client_document_link(client: Client, uri: str, expected):
         ),
     ],
 )
-async def test_client_document_symbol(client: Client, uri: str, expected):
+async def test_client_document_symbol(client: LanguageClient, uri: str, expected):
     """Ensure that the client can handle document symbol responses correctly"""
 
     response = await client.document_symbols_request(uri)
@@ -192,10 +204,10 @@ async def test_client_document_symbol(client: Client, uri: str, expected):
         ),
     ],
 )
-async def test_client_hover(client: Client, line: int, expected):
+async def test_client_hover(client: LanguageClient, line: int, expected):
     """Ensure that the client can handle hover responses correctly"""
 
-    response = await client.hover_request(TEST_URI, Position(line=line, character=0))
+    response = await client.hover_request(TEST_URI, line=line, character=0)
     assert response == expected
 
 
@@ -223,11 +235,11 @@ async def test_client_hover(client: Client, line: int, expected):
         ),
     ],
 )
-async def test_client_implementation(client: Client, line: int, expected):
+async def test_client_implementation(client: LanguageClient, line: int, expected):
     """Ensure that the client can handle implementation responses correctly"""
 
     response = await client.implementation_request(
-        TEST_URI, Position(line=line, character=0)
+        TEST_URI, line=line, character=0
     )
 
     assert response == expected

--- a/lib/pytest-lsp/tests/test_plugin.py
+++ b/lib/pytest-lsp/tests/test_plugin.py
@@ -59,9 +59,13 @@ async def test_capabilities(client):
     results = pytester.runpytest('-vv')
 
     results.assert_outcomes(errors=1)
-    results.stdout.fnmatch_lines(
-        "E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 0"
-    )
+
+    if sys.version_info.minor < 9:
+        message = "E*CancelledError"
+    else:
+        message = "E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 0"
+
+    results.stdout.fnmatch_lines(message)
 
 
 def test_detect_server_exit_mid_request(pytester: pytest.Pytester):
@@ -91,9 +95,13 @@ async def test_capabilities(client):
     results = pytester.runpytest('-vv')
 
     results.assert_outcomes(errors=1)
-    results.stdout.fnmatch_lines(
-        "E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 0"
-    )
+
+    if sys.version_info.minor < 9:
+        message = "E*CancelledError"
+    else:
+        message = "E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 0"
+
+    results.stdout.fnmatch_lines(message)
 
 
 def test_detect_server_crash(pytester: pytest.Pytester):
@@ -111,10 +119,16 @@ async def test_capabilities(client):
     results = pytester.runpytest("-vv")
 
     results.assert_outcomes(errors=1)
-    results.stdout.fnmatch_lines(
-        ["E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 1",
-         "E*ZeroDivisionError: division by zero"]
-    )
+
+    if sys.version_info.minor < 9:
+        message = "E*CancelledError"
+    else:
+        message = [
+            "E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 1",
+            "E*ZeroDivisionError: division by zero"
+        ]
+
+    results.stdout.fnmatch_lines(message)
 
 
 def test_detect_invalid_json(pytester: pytest.Pytester):
@@ -145,6 +159,10 @@ async def test_capabilities(client):
     results = pytester.runpytest('-vv')
 
     results.assert_outcomes(failed=1)
-    results.stdout.fnmatch_lines(
-        "E*asyncio.exceptions.CancelledError: JsonRpcInternalError: *"
-    )
+
+    if sys.version_info.minor < 9:
+        message = "E*CancelledError"
+    else:
+        message = "E*asyncio.exceptions.CancelledError: JsonRpcInternalError: *"
+
+    results.stdout.fnmatch_lines(message)

--- a/lib/pytest-lsp/tests/test_plugin.py
+++ b/lib/pytest-lsp/tests/test_plugin.py
@@ -1,0 +1,150 @@
+import itertools
+import json
+import pathlib
+import sys
+
+import pytest
+import pytest_lsp
+import pygls.uris as uri
+
+
+def setup_test(pytester: pytest.Pytester, server_name: str, test_code: str):
+    """Boilerplate for setting up a test."""
+
+    python = sys.executable
+    testdir = pathlib.Path(__file__).parent
+
+    server = testdir / "servers" / server_name
+    root_uri = uri.from_fs_path(str(testdir))
+
+    pytester.makeini(
+        """\
+[pytest]
+asyncio_mode = auto
+"""
+    )
+
+    pytester.makeconftest(
+        f"""
+import pytest_lsp
+from pytest_lsp import ClientServerConfig
+
+@pytest_lsp.fixture(
+    config=ClientServerConfig(
+        client="visual_studio_code",
+        server_command=["{python}", "{server}"],
+        root_uri="{root_uri}"
+    )
+)
+async def client(client_):
+    ...
+    """
+    )
+
+    pytester.makepyfile(test_code)
+
+
+def test_detect_server_exit(pytester: pytest.Pytester):
+    """Ensure that the plugin can detect when the server process exits."""
+
+    test_code = """\
+import pytest
+
+@pytest.mark.asyncio
+async def test_capabilities(client):
+    ...  # Test code does not matter in this case, as the error should be in the setup.
+"""
+
+    setup_test(pytester, "hello.py", test_code)
+    results = pytester.runpytest('-vv')
+
+    results.assert_outcomes(errors=1)
+    results.stdout.fnmatch_lines(
+        "E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 0"
+    )
+
+
+def test_detect_server_exit_mid_request(pytester: pytest.Pytester):
+    """Ensure that the plugin can detect when the server process exits mid request."""
+
+    test_code = """\
+import pytest
+from lsprotocol.types import CompletionParams
+from lsprotocol.types import Position
+from lsprotocol.types import TextDocumentIdentifier
+
+
+@pytest.mark.asyncio
+async def test_capabilities(client):
+    expected = {str(i) for i in range(10)}
+
+    for i in range(10):
+        params = CompletionParams(
+            text_document=TextDocumentIdentifier(uri="file:///test.txt"),
+            position=Position(line=0, character=0)
+        )
+        items = await client.text_document_completion_request()
+        assert len({i.label for i in items} & expected) == len(items)
+"""
+
+    setup_test(pytester, "completion_exit.py", test_code)
+    results = pytester.runpytest('-vv')
+
+    results.assert_outcomes(errors=1)
+    results.stdout.fnmatch_lines(
+        "E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 0"
+    )
+
+
+def test_detect_server_crash(pytester: pytest.Pytester):
+    """Ensure the plugin can detect when the server process crashes on boot."""
+
+    test_code = """\
+import pytest
+
+@pytest.mark.asyncio
+async def test_capabilities(client):
+    ... # Test code does not matter in this case, as the error should be in the setup.
+"""
+
+    setup_test(pytester, "crash.py", test_code)
+    results = pytester.runpytest("-vv")
+
+    results.assert_outcomes(errors=1)
+    results.stdout.fnmatch_lines(
+        ["E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 1",
+         "E*ZeroDivisionError: division by zero"]
+    )
+
+
+def test_detect_invalid_json(pytester: pytest.Pytester):
+    """Ensure that the plugin can detect when the server sends bad JSON."""
+
+    test_code = """\
+import pytest
+from lsprotocol.types import CompletionParams
+from lsprotocol.types import Position
+from lsprotocol.types import TextDocumentIdentifier
+
+
+@pytest.mark.asyncio
+async def test_capabilities(client):
+    expected = {str(i) for i in range(10)}
+
+    for i in range(10):
+        items = await client.text_document_completion_request(
+            CompletionParams(
+                text_document=TextDocumentIdentifier(uri="file:///test.txt"),
+                position=Position(line=0, character=0)
+            )
+        )
+        assert len({i.label for i in items} & expected) == len(items)
+"""
+
+    setup_test(pytester, "invalid_json.py", test_code)
+    results = pytester.runpytest('-vv')
+
+    results.assert_outcomes(failed=1)
+    results.stdout.fnmatch_lines(
+        "E*asyncio.exceptions.CancelledError: JsonRpcInternalError: *"
+    )

--- a/scripts/gen_client.py
+++ b/scripts/gen_client.py
@@ -1,0 +1,159 @@
+"""Script to automatically generate a lanaguge client from `lsprotocol` type definitons
+"""
+import argparse
+import inspect
+import pathlib
+import re
+import sys
+import textwrap
+from datetime import datetime
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
+
+from lsprotocol._hooks import _resolve_forward_references
+from lsprotocol.types import METHOD_TO_TYPES
+from lsprotocol.types import message_direction
+
+cli = argparse.ArgumentParser(
+    description="generate language client from lsprotocol types."
+)
+cli.add_argument("-o", "--output", default=None)
+
+
+def write_imports(imports: List[Union[str, Tuple[str, str]]]) -> str:
+    lines = []
+
+    for import_ in sorted(imports, key=lambda i: (i[0], i[1])):
+        if isinstance(import_, tuple):
+            mod, name = import_
+            lines.append(f"from {mod} import {name}")
+            continue
+
+        lines.append(f"import {import_}")
+
+    return "\n".join(lines)
+
+
+def to_snake_case(string: str) -> str:
+    return "".join(f"_{c.lower()}" if c.isupper() else c for c in string)
+
+
+def write_notification(
+    method: str,
+    request: Type,
+    params: Optional[Type],
+    imports: List[Union[str, Tuple[str, str]]],
+) -> str:
+
+    python_name = to_snake_case(method).replace("/", "_").replace("$_", "")
+
+    if params is None:
+        param_name = "None"
+    else:
+        param_mod, param_name = params.__module__, params.__name__
+        imports.append((param_mod, param_name))
+
+    return "\n".join(
+        [
+            f"def notify_{python_name}(self, params: {param_name}) -> None:",
+            f'    """Send a ``{method}`` notification.',
+            "",
+            textwrap.indent(inspect.getdoc(request) or "", "    "),
+            '    """',
+            f'    self.lsp.notify("{method}", params)',
+            "",
+        ]
+    )
+
+
+def write_method(
+    method: str,
+    request: Type,
+    params: Optional[Type],
+    response: Type,
+    imports: List[Union[str, Tuple[str, str]]],
+) -> str:
+
+    python_name = to_snake_case(method).replace("/", "_").replace("$_", "")
+
+    if params is None:
+        param_name = "None"
+    else:
+        param_mod, param_name = params.__module__, params.__name__
+        imports.append((param_mod, param_name))
+
+    # Find the response type.
+    result_field = [f for f in response.__attrs_attrs__ if f.name == "result"][0]
+    result = re.sub(r"<class '([\w.]+)'>", r"\1", str(result_field.type))
+    result = re.sub(r"ForwardRef\('([\w.]+)'\)", r"lsprotocol.types.\1", result)
+    result = result.replace("NoneType", "None")
+
+    return "\n".join(
+        [
+            f"async def {python_name}_request(self, params: {param_name}) -> {result}:",
+            f'    """Make a ``{method}`` request.',
+            "",
+            textwrap.indent(inspect.getdoc(request) or "", "    "),
+            '    """',
+            f'    return await self.lsp.send_request_async("{method}", params)',
+            "",
+        ]
+    )
+
+
+def generate_client() -> str:
+
+    methods = []
+    imports = [
+        "typing",
+        "lsprotocol.types",
+        ("pygls.server", "Server"),
+    ]
+
+    for method_name, types in METHOD_TO_TYPES.items():
+
+        if message_direction(method_name) == "serverToClient":
+            continue
+
+        request, response, params, _ = types
+
+        if response is None:
+            method = write_notification(method_name, request, params, imports)
+        else:
+            method = write_method(method_name, request, params, response, imports)
+
+        methods.append(textwrap.indent(method, "    "))
+
+    code = [
+        "# GENERATED FROM scripts/gen-client.py -- DO NOT EDIT",
+        f"# Last Modified: {datetime.now()}",
+        write_imports(imports),
+        "",
+        "",
+        "class Client(Server):",
+        '    """Used to drive the language server under test."""',
+        "",
+        *methods,
+    ]
+    return "\n".join(code)
+
+
+def main():
+    args = cli.parse_args()
+
+    # Make sure all the type annotations in lsprotocol are resolved correctly.
+    _resolve_forward_references()
+    client = generate_client()
+
+    if args.output is None:
+        sys.stdout.write(client)
+    else:
+        output = pathlib.Path(args.output)
+        output.write_text(client)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Drop Python 3.6 support
- Migrate to `pygls` v1.0
- Provide an autogenerated `LanguageClient` based on `lsprotocol` types
- Fixes for hanging tests in some scenarios (I expect there will be more)
- Add initial docs site and workflows