### PR TITLE
pytest-lsp: Simplify architecture

### DIFF
--- a/lib/pytest-lsp/pytest_lsp/__init__.py
+++ b/lib/pytest-lsp/pytest_lsp/__init__.py
@@ -5,6 +5,7 @@ from .plugin import ClientServerConfig
 from .plugin import fixture
 from .plugin import make_client_server
 from .plugin import pytest_runtest_makereport
+from .plugin import pytest_runtest_setup
 
 __version__ = "0.2.1"
 
@@ -16,4 +17,5 @@ __all__ = [
     "make_client_server",
     "make_test_client",
     "pytest_runtest_makereport",
+    "pytest_runtest_setup",
 ]

--- a/lib/pytest-lsp/tests/servers/invalid_json.py
+++ b/lib/pytest-lsp/tests/servers/invalid_json.py
@@ -31,5 +31,5 @@ def on_complete(server: LanguageServer, params: CompletionParams):
     return [CompletionItem(label="item-one")]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     server.start_io()

--- a/lib/pytest-lsp/tests/servers/invalid_json.py
+++ b/lib/pytest-lsp/tests/servers/invalid_json.py
@@ -31,4 +31,5 @@ def on_complete(server: LanguageServer, params: CompletionParams):
     return [CompletionItem(label="item-one")]
 
 
-server.start_io()
+if __name__ == '__main__':
+    server.start_io()

--- a/lib/pytest-lsp/tests/test_plugin.py
+++ b/lib/pytest-lsp/tests/test_plugin.py
@@ -155,7 +155,7 @@ async def test_capabilities(client):
     setup_test(pytester, "invalid_json.py", test_code)
     results = pytester.runpytest("-vv")
 
-    results.assert_outcomes(failed=1)
+    results.assert_outcomes(errors=1, failed=1)
 
     if sys.version_info.minor < 9:
         message = "E*CancelledError"


### PR DESCRIPTION
Instead of spinning up multiple threads, to run the client-server connection, to monitor the server process etc. everything is now run on a single event loop on the main thread.

This simplifies the setup/teardown and hopefully makes things more robust in the long run.