### PR TITLE
Refactor how the `ClientServer` works

### DIFF
--- a/docs/pytest-lsp/getting-started.rst
+++ b/docs/pytest-lsp/getting-started.rst
@@ -1,4 +1,127 @@
 Getting Started
 ===============
 
-Coming soon
+This guide will walk you through the process of writing your first test case using ``pytest-lsp``.
+
+A Simple Language Server
+------------------------
+
+Before we can write any tests, we need a language server to test!
+For the purposes of this example we'll write a simple language server in Python using the `pygls`_ library but note that ``pytest-lsp`` should work with language servers written in any language or framework.
+
+The following server implements the ``textDocument/completion`` method
+
+.. literalinclude:: ../../lib/pytest-lsp/tests/examples/getting-started/server.py
+   :language: python
+   :end-at: ]
+
+Copy and paste the above code into a file named ``server.py``.
+
+A Simple Test Case
+------------------
+
+Now we can go ahead and test it.
+Copy the following code and save it into a file named ``test_server.py``, in the same directory as the ``server.py`` file you created in the previous step.
+
+.. literalinclude:: ../../lib/pytest-lsp/tests/examples/getting-started/t_server.py
+   :language: python
+   :end-at: await lsp_client.shutdown()
+
+This creates a `pytest fixture`_ named ``client``, it uses the given ``server_command`` to automatically launch the server in a background process and connect it to a ``LanguageClient`` instance.
+
+The setup code (everything before the ``yield``) statement is executed before any tests run, calling ``initialize`` on the client to open the LSP session.
+
+Once all test cases have been called, the code after the ``yield`` statement will be called to shutdown the server and close the session
+
+With the framework in place, we can go ahead and define our first test case
+
+.. literalinclude:: ../../lib/pytest-lsp/tests/examples/getting-started/t_server.py
+   :language: python
+   :start-at: async def test_
+
+All that's left is to run the test suite!
+
+.. code-block:: none
+
+   $ pytest
+   ================================================ test session starts =================================================
+   platform linux -- Python 3.11.2, pytest-7.2.0, pluggy-1.0.0
+   rootdir: /var/home/user/Projects/lsp-devtools/lib/pytest-lsp, configfile: pyproject.toml
+   plugins: typeguard-2.13.3, asyncio-0.20.2, lsp-0.2.1
+   asyncio: mode=Mode.AUTO
+   collected 1 item
+
+   test_server.py E                                                                                               [100%]
+
+   ======================================================= ERRORS =======================================================
+   _________________________________________ ERROR at setup of test_completions _________________________________________
+
+   lsp_client = <pytest_lsp.client.LanguageClient object at 0x7f9bd7e22050>
+
+       @pytest_lsp.fixture(
+           config=ClientServerConfig(server_command=[sys.executable, "server.py"]),
+       )
+       async def client(lsp_client: LanguageClient):
+           # Setup
+           params = InitializeParams(capabilities=ClientCapabilities())
+   >       await lsp_client.initialize(params)
+
+   test_server.py:18:
+   _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+   ../../pytest_lsp/client.py:342: in initialize
+       response = await self.initialize_request(params)
+   _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+   self = <pytest_lsp.client.LanguageClient object at 0x7f9bd7e22050>
+   params = InitializeParams(capabilities=ClientCapabilities(workspace=None, text_document=None, notebook_document=None, window=No..., root_path=None, root_uri=None, initialization_options=None, trace=None, work_done_token=None, workspace_folders=None)
+
+       async def initialize_request(self, params: InitializeParams) -> lsprotocol.types.InitializeResult:
+           """Make a ``initialize`` request.
+
+           The initialize request is sent from the client to the server.
+
+           It is sent once as the request after starting up the server. The
+           requests parameter is of type {@link InitializeParams} the response
+           if of type {@link InitializeResult} of a Thenable that resolves to
+           such.
+           """
+   >       return await self.lsp.send_request_async("initialize", params)
+   E       asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 0
+   E
+   E       NoneType: None
+
+   ../../pytest_lsp/gen.py:146: CancelledError
+   ============================================== short test summary info ===============================================
+   ERROR test_server.py::test_completions - asyncio.exceptions.CancelledError: RuntimeError: Server exited with return...
+   ================================================== 1 error in 1.14s ==================================================
+
+Ah, looks like we forgot to start the server.
+Add the following to the bottom of ``server.py``.
+
+.. code-block:: python
+
+   if __name__ == "__main__":
+       server.start_io()
+
+Let's try again
+
+
+.. code-block:: none
+
+   $ pytest
+   ================================================ test session starts =================================================
+   platform linux -- Python 3.11.2, pytest-7.2.0, pluggy-1.0.0
+   rootdir: /var/home/user/Projects/lsp-devtools/lib/pytest-lsp, configfile: pyproject.toml
+   plugins: typeguard-2.13.3, asyncio-0.20.2, lsp-0.2.1
+   asyncio: mode=Mode.AUTO
+   collected 1 item
+
+   test_server.py .                                                                                               [100%]
+
+   ================================================= 1 passed in 0.96s ==================================================
+
+Much bettter!
+
+
+.. _pygls: https://github.com/openlawlibrary/pygls
+.. _pytest fixture: https://docs.pytest.org/en/7.1.x/how-to/fixtures.html

--- a/lib/pytest-lsp/pytest_lsp/__init__.py
+++ b/lib/pytest-lsp/pytest_lsp/__init__.py
@@ -1,4 +1,5 @@
 from .client import LanguageClient
+from .client import client_capabilities
 from .client import make_test_client
 from .plugin import ClientServer
 from .plugin import ClientServerConfig
@@ -13,6 +14,7 @@ __all__ = [
     "ClientServer",
     "ClientServerConfig",
     "LanguageClient",
+    "client_capabilities",
     "fixture",
     "make_client_server",
     "make_test_client",

--- a/lib/pytest-lsp/pytest_lsp/plugin.py
+++ b/lib/pytest-lsp/pytest_lsp/plugin.py
@@ -1,38 +1,23 @@
 import asyncio
 import inspect
-import json
 import logging
-import os
 import subprocess
 import sys
 import textwrap
 import threading
+import typing
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
 from typing import Callable
-from typing import Iterable
 from typing import List
 from typing import Optional
-from typing import Union
 
 import pytest
 import pytest_asyncio
-from lsprotocol.converters import get_converter
-from lsprotocol.types import ClientCapabilities
-from lsprotocol.types import InitializedParams
-from lsprotocol.types import InitializeParams
-from lsprotocol.types import LSPAny
 from pygls.server import StdOutTransportAdapter
 from pygls.server import aio_readline
 
 from pytest_lsp.client import LanguageClient
 from pytest_lsp.client import make_test_client
-
-if sys.version_info.minor < 9:
-    import importlib_resources as resources
-else:
-    import importlib.resources as resources  # type: ignore[no-redef]
-
 
 logger = logging.getLogger("client")
 
@@ -58,33 +43,17 @@ async def check_server_process(
 class ClientServer:
     """A client server pair used to drive test cases."""
 
-    def __init__(
-        self,
-        client: LanguageClient,
-        server: subprocess.Popen,
-        root_uri: str,
-        client_capabilities: ClientCapabilities,
-        initialization_options: Optional[LSPAny],
-    ):
+    def __init__(self, *, client: LanguageClient, server: subprocess.Popen):
         self.server = server
         """The process object running the server."""
 
         self.client = client
         """The client used to drive the test."""
 
-        self.client_capabilities = client_capabilities
-        """The capabilities of the client."""
-
-        self.initialization_options = initialization_options
-        """The initialization options to pass to the server."""
-
-        self.root_uri = root_uri
-        """The root uri to point the server at."""
-
         self._thread_pool_executor = ThreadPoolExecutor(max_workers=2)
         self._stop_event = threading.Event()
 
-    async def start(self):
+    def start(self):
         loop = asyncio.get_running_loop()
 
         self.client._stop_event = self._stop_event
@@ -117,29 +86,8 @@ class ClientServer:
             **watch_name,  # type: ignore[arg-type]
         )
 
-        response = await self.client.initialize_request(
-            InitializeParams(
-                process_id=os.getpid(),
-                root_uri=self.root_uri,
-                capabilities=self.client_capabilities,
-                initialization_options=self.initialization_options,
-            ),
-        )
-
-        assert response.capabilities is not None
-        self.client.notify_initialized(InitializedParams())
-
-        return response
-
     async def stop(self):
-        # Only attempt if there wasn't an error.
-        if self.client.error is None:
-            response = await self.client.shutdown_request(None)  # type: ignore
-            assert response is None
-
-            self.client.notify_exit(None)
-        else:
-            self.server.terminate()
+        self.server.terminate()
 
         if self.client._stop_event:
             self.client._stop_event.set()
@@ -154,12 +102,8 @@ class ClientServerConfig:
     def __init__(
         self,
         server_command: List[str],
-        root_uri: str,
         *,
-        client: str = "",
-        client_capabilities: Optional[ClientCapabilities] = None,
-        client_factory: Callable[..., LanguageClient] = make_test_client,
-        initialization_options: Optional[Any] = None,
+        client_factory: Callable[[], LanguageClient] = make_test_client,
     ) -> None:
         """
         Parameters
@@ -167,57 +111,13 @@ class ClientServerConfig:
         server_command
            The command to use to start the language server.
 
-        root_uri
-           The root uri to start the language server in
-
-        client
-           The name of the client profile to use
-
-        client_capabilities
-           Use to use a specific set of client, capabilities.
-           Specifiying this will override ``client``.
-
         client_factory
            Factory function to use when constructing the language client instance.
            Defaults to :func:`pytest_lsp.make_test_client`
-
-        initialization_options
-           The initialization options to pass to the server on start up.
-
         """
 
         self.server_command = server_command
-        self.root_uri = root_uri
-        self.client = client
-        self.client_capabilities = client_capabilities
         self.client_factory = client_factory
-        self.initialization_options = initialization_options
-
-
-def find_client_capabilities(client: str) -> ClientCapabilities:
-    """Find the capabilities that correspond to the given client spec."""
-
-    # Currently, we only have a single version of each client so let's just return the
-    # first one we find.
-    #
-    # TODO: Implement support for client@x.y.z
-    # TODO: Implement support for client@latest?
-    filename = None
-    for resource in resources.files("pytest_lsp.clients").iterdir():
-        # Skip the README or any other files that we don't care about.
-        if not resource.name.endswith(".json"):
-            continue
-
-        if resource.name.startswith(client.replace("-", "_")):
-            filename = resource
-            break
-
-    if not filename:
-        raise ValueError(f"Unsupported client '{client}'")
-
-    converter = get_converter()
-    capabilities = json.loads(filename.read_text())
-    return converter.structure(capabilities, ClientCapabilities)
 
 
 def make_client_server(config: ClientServerConfig) -> ClientServer:
@@ -230,21 +130,9 @@ def make_client_server(config: ClientServerConfig) -> ClientServer:
         stderr=subprocess.PIPE,
     )
 
-    if config.client_capabilities:
-        capabilities = config.client_capabilities
-    elif config.client:
-        capabilities = find_client_capabilities(config.client)
-    else:
-        capabilities = ClientCapabilities()
-
-    client = config.client_factory(capabilities, config.root_uri)
-
     return ClientServer(
-        client=client,
         server=server,
-        client_capabilities=capabilities,
-        root_uri=config.root_uri,
-        initialization_options=config.initialization_options,
+        client=config.client_factory(),
     )
 
 
@@ -299,34 +187,36 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
 def fixture(
     fixture_function=None,
     *,
-    config: Union[ClientServerConfig, Iterable[ClientServerConfig]],
+    config: ClientServerConfig,
     **kwargs,
 ):
-    if isinstance(config, ClientServerConfig):
-        params = [config]
-    else:
-        params = list(config)
-
-    ids = [conf.client or f"client{idx}" for idx, conf in enumerate(params)]
-
     def wrapper(fn):
-        @pytest_asyncio.fixture(params=params, ids=ids, **kwargs)
+        @pytest_asyncio.fixture(**kwargs)
         async def the_fixture(request):
-            lsp = make_client_server(request.param)
-            await lsp.start()
+            client_server = make_client_server(config)
+            client_server.start()
 
-            # TODO: Do this 'properly'
-            signature = inspect.signature(fn)
-            if "client_" in signature.parameters.keys():
-                await fn(lsp.client)
-            else:
-                await fn()
+            kwargs = {}
+            for name, cls in typing.get_type_hints(fn).items():
+                if issubclass(cls, LanguageClient):
+                    kwargs[name] = client_server.client
 
-            lsp.client._setup_log_index = len(lsp.client.log_messages)
-            lsp.client._last_log_index = len(lsp.client.log_messages)
+            result = fn(**kwargs)
+            if inspect.isasyncgen(result):
+                try:
+                    await anext(result)
+                except StopAsyncIteration:
+                    pass
 
-            yield lsp.client
-            await lsp.stop()
+            yield client_server.client
+
+            if inspect.isasyncgen(result):
+                try:
+                    await anext(result)
+                except StopAsyncIteration:
+                    pass
+
+            await client_server.stop()
 
         return the_fixture
 

--- a/lib/pytest-lsp/pytest_lsp/plugin.py
+++ b/lib/pytest-lsp/pytest_lsp/plugin.py
@@ -184,6 +184,13 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
         item.add_report_section(call.when, "window/logMessages", "\n".join(messages))
 
 
+# anext() was added in 3.10
+if sys.version_info.minor < 10:
+
+    async def anext(it):
+        return await it.__anext__()
+
+
 def fixture(
     fixture_function=None,
     *,

--- a/lib/pytest-lsp/tests/examples/getting-started-fail/server.py
+++ b/lib/pytest-lsp/tests/examples/getting-started-fail/server.py
@@ -1,0 +1,14 @@
+from lsprotocol.types import TEXT_DOCUMENT_COMPLETION
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import CompletionParams
+from pygls.server import LanguageServer
+
+server = LanguageServer("hello-world", "v1")
+
+
+@server.feature(TEXT_DOCUMENT_COMPLETION)
+def completion(ls: LanguageServer, params: CompletionParams):
+    return [
+        CompletionItem(label="hello"),
+        CompletionItem(label="world"),
+    ]

--- a/lib/pytest-lsp/tests/examples/getting-started-fail/t_server.py
+++ b/lib/pytest-lsp/tests/examples/getting-started-fail/t_server.py
@@ -1,0 +1,33 @@
+import sys
+
+from lsprotocol.types import ClientCapabilities
+from lsprotocol.types import InitializeParams
+
+import pytest_lsp
+from pytest_lsp.client import LanguageClient
+from pytest_lsp.plugin import ClientServerConfig
+
+
+@pytest_lsp.fixture(
+    config=ClientServerConfig(server_command=[sys.executable, "server.py"]),
+)
+async def client(lsp_client: LanguageClient):
+    # Setup
+    params = InitializeParams(capabilities=ClientCapabilities())
+    await lsp_client.initialize(params)
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown()
+
+
+async def test_completions(client: LanguageClient):
+    """Ensure that the server implements completions correctly."""
+
+    results = await client.completion_request(
+        uri="file:///path/to/file.txt", line=1, character=0
+    )
+
+    labels = [item.label for item in results]
+    assert labels == ["hello", "world"]

--- a/lib/pytest-lsp/tests/examples/getting-started/server.py
+++ b/lib/pytest-lsp/tests/examples/getting-started/server.py
@@ -1,0 +1,18 @@
+from lsprotocol.types import TEXT_DOCUMENT_COMPLETION
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import CompletionParams
+from pygls.server import LanguageServer
+
+server = LanguageServer("hello-world", "v1")
+
+
+@server.feature(TEXT_DOCUMENT_COMPLETION)
+def completion(ls: LanguageServer, params: CompletionParams):
+    return [
+        CompletionItem(label="hello"),
+        CompletionItem(label="world"),
+    ]
+
+
+if __name__ == "__main__":
+    server.start_io()

--- a/lib/pytest-lsp/tests/examples/getting-started/t_server.py
+++ b/lib/pytest-lsp/tests/examples/getting-started/t_server.py
@@ -1,0 +1,33 @@
+import sys
+
+from lsprotocol.types import ClientCapabilities
+from lsprotocol.types import InitializeParams
+
+import pytest_lsp
+from pytest_lsp.client import LanguageClient
+from pytest_lsp.plugin import ClientServerConfig
+
+
+@pytest_lsp.fixture(
+    config=ClientServerConfig(server_command=[sys.executable, "server.py"]),
+)
+async def client(lsp_client: LanguageClient):
+    # Setup
+    params = InitializeParams(capabilities=ClientCapabilities())
+    await lsp_client.initialize(params)
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown()
+
+
+async def test_completions(client: LanguageClient):
+    """Ensure that the server implements completions correctly."""
+
+    results = await client.completion_request(
+        uri="file:///path/to/file.txt", line=1, character=0
+    )
+
+    labels = [item.label for item in results]
+    assert labels == ["hello", "world"]

--- a/lib/pytest-lsp/tests/test_client.py
+++ b/lib/pytest-lsp/tests/test_client.py
@@ -5,6 +5,7 @@ import sys
 
 import pygls.uris as uri
 import pytest
+
 import pytest_lsp
 
 
@@ -42,18 +43,28 @@ def test_client_capabilities(
 
     pytester.makeconftest(
         f"""
+from lsprotocol.types import InitializeParams
+
 import pytest_lsp
 from pytest_lsp import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import client_capabilities
 
 @pytest_lsp.fixture(
     config=ClientServerConfig(
-        client="{client_spec}",
         server_command=["{python}", "{server}"],
-        root_uri="{root_uri}"
     )
 )
-async def client(client_):
-    ...
+async def client(lsp_client: LanguageClient):
+    await lsp_client.initialize(
+        InitializeParams(
+            capabilities=client_capabilities("{client_spec}"),
+            root_uri="{root_uri}"
+        )
+    )
+    yield
+
+    await lsp_client.shutdown()
     """
     )
 

--- a/lib/pytest-lsp/tests/test_client_methods.py
+++ b/lib/pytest-lsp/tests/test_client_methods.py
@@ -4,12 +4,13 @@ import sys
 
 import pygls.uris as uri
 import pytest
-import pytest_lsp
+from lsprotocol.types import ClientCapabilities
 from lsprotocol.types import CompletionItem
 from lsprotocol.types import CompletionList
 from lsprotocol.types import DocumentLink
 from lsprotocol.types import DocumentSymbol
 from lsprotocol.types import Hover
+from lsprotocol.types import InitializeParams
 from lsprotocol.types import Location
 from lsprotocol.types import LocationLink
 from lsprotocol.types import MarkupContent
@@ -18,6 +19,8 @@ from lsprotocol.types import Position
 from lsprotocol.types import Range
 from lsprotocol.types import SymbolInformation
 from lsprotocol.types import SymbolKind
+
+import pytest_lsp
 from pytest_lsp import ClientServerConfig
 from pytest_lsp import LanguageClient
 
@@ -51,16 +54,19 @@ def event_loop():
 @pytest_lsp.fixture(
     scope="session",
     config=ClientServerConfig(
-        client="visual_studio_code",
         server_command=[
             sys.executable,
             str(pathlib.Path(__file__).parent / "servers" / "methods.py"),
         ],
-        root_uri=ROOT_URI,
     ),
 )
-async def client(client_):
-    ...
+async def client(lsp_client: LanguageClient):
+    await lsp_client.initialize(
+        InitializeParams(
+            capabilities=ClientCapabilities(),
+            root_uri=ROOT_URI,
+        )
+    )
 
 
 @pytest.mark.parametrize(

--- a/lib/pytest-lsp/tests/test_examples.py
+++ b/lib/pytest-lsp/tests/test_examples.py
@@ -1,0 +1,47 @@
+import pathlib
+import sys
+
+import pytest
+
+EXAMPLES = pathlib.Path(__file__).parent / "examples"
+
+
+def setup_test(pytester: pytest.Pytester, example_name: str):
+    pytester.makeini(
+        """\
+[pytest]
+asyncio_mode = auto
+"""
+    )
+
+    for src in (EXAMPLES / example_name).glob("*.py"):
+        if not src.is_file():
+            continue
+
+        dest = pytester.path / src.name.replace("t_", "test_")
+        dest.write_text(src.read_text())
+
+
+def test_getting_started(pytester: pytest.Pytester):
+    """Ensure that the initial getting started exampl eworks as expected."""
+
+    setup_test(pytester, "getting-started")
+
+    results = pytester.runpytest("-vv")
+    results.assert_outcomes(passed=1)
+
+
+def test_getting_started_fail(pytester: pytest.Pytester):
+    """Ensure that the initial getting started example fails as expected."""
+
+    setup_test(pytester, "getting-started-fail")
+
+    results = pytester.runpytest("-vv")
+    results.assert_outcomes(errors=1)
+
+    if sys.version_info.minor < 9:
+        message = "E*CancelledError"
+    else:
+        message = "E*asyncio.exceptions.CancelledError: RuntimeError: Server exited with return code: 0"  # noqa: E501
+
+    results.stdout.fnmatch_lines(message)

--- a/lib/pytest-lsp/tests/test_plugin.py
+++ b/lib/pytest-lsp/tests/test_plugin.py
@@ -23,18 +23,29 @@ asyncio_mode = auto
 
     pytester.makeconftest(
         f"""
+from lsprotocol.types import InitializeParams
+
 import pytest_lsp
 from pytest_lsp import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import client_capabilities
+
 
 @pytest_lsp.fixture(
     config=ClientServerConfig(
-        client="visual_studio_code",
         server_command=["{python}", "{server}"],
-        root_uri="{root_uri}"
     )
 )
-async def client(client_):
-    ...
+async def client(lsp_client: LanguageClient):
+    await lsp_client.initialize(
+        InitializeParams(
+            capabilities=client_capabilities("visual-studio-code"),
+            root_uri="{root_uri}"
+        )
+    )
+    yield
+
+    await lsp_client.shutdown()
     """
     )
 


### PR DESCRIPTION
The `ClientServer` object no longer automatically initializes or shutsdown the LSP session. It *does* however, still start and stop the client/server pair.

In fact, the `ClientServer` object shouldn't rely on anything LSP specific, which should open the door to using `pytest_lsp` to test any JSON-RPC based protocol in the future.

This means that fixture functions annotated with the `@pytest_lsp.fixture` decorator are now responsible for initializing and shutting down the LSP session, also granting the test author greater control over the initial setup.