### PR TITLE
Re-enable fixture parameterisation

### DIFF
--- a/docs/pytest-lsp/guide/fixtures.rst
+++ b/docs/pytest-lsp/guide/fixtures.rst
@@ -24,3 +24,15 @@ To fix this you can override the ``event_loop`` fixture, setting its scope to ma
    :end-at: loop.close()
 
 .. _pytest-asyncio: https://github.com/pytest-dev/pytest-asyncio
+
+
+Parameterised Fixtures
+----------------------
+
+Like regular pytest fixtures, :func:`pytest_lsp.fixture` supports `parameterisation <https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#parametrizing-fixtures>`__.
+This can be used to run the same set of tests while pretending to be a different client each time.
+
+.. literalinclude:: ../../../lib/pytest-lsp/tests/examples/parameterised-clients/t_server.py
+   :language: python
+   :start-at: @pytest_lsp.fixture
+   :end-at: await lsp_client.shutdown()

--- a/lib/pytest-lsp/tests/examples/diagnostics/t_server.py
+++ b/lib/pytest-lsp/tests/examples/diagnostics/t_server.py
@@ -5,8 +5,8 @@ from lsprotocol.types import ClientCapabilities
 from lsprotocol.types import InitializeParams
 
 import pytest_lsp
-from pytest_lsp.client import LanguageClient
-from pytest_lsp.plugin import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import ClientServerConfig
 
 
 @pytest_lsp.fixture(

--- a/lib/pytest-lsp/tests/examples/getting-started-fail/t_server.py
+++ b/lib/pytest-lsp/tests/examples/getting-started-fail/t_server.py
@@ -4,8 +4,8 @@ from lsprotocol.types import ClientCapabilities
 from lsprotocol.types import InitializeParams
 
 import pytest_lsp
-from pytest_lsp.client import LanguageClient
-from pytest_lsp.plugin import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import ClientServerConfig
 
 
 @pytest_lsp.fixture(

--- a/lib/pytest-lsp/tests/examples/getting-started/t_server.py
+++ b/lib/pytest-lsp/tests/examples/getting-started/t_server.py
@@ -4,8 +4,8 @@ from lsprotocol.types import ClientCapabilities
 from lsprotocol.types import InitializeParams
 
 import pytest_lsp
-from pytest_lsp.client import LanguageClient
-from pytest_lsp.plugin import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import ClientServerConfig
 
 
 @pytest_lsp.fixture(

--- a/lib/pytest-lsp/tests/examples/parameterised-clients/server.py
+++ b/lib/pytest-lsp/tests/examples/parameterised-clients/server.py
@@ -1,0 +1,18 @@
+from lsprotocol.types import TEXT_DOCUMENT_COMPLETION
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import CompletionParams
+from pygls.server import LanguageServer
+
+server = LanguageServer("hello-world", "v1")
+
+
+@server.feature(TEXT_DOCUMENT_COMPLETION)
+def completion(ls: LanguageServer, params: CompletionParams):
+    return [
+        CompletionItem(label="hello"),
+        CompletionItem(label="world"),
+    ]
+
+
+if __name__ == "__main__":
+    server.start_io()

--- a/lib/pytest-lsp/tests/examples/parameterised-clients/t_server.py
+++ b/lib/pytest-lsp/tests/examples/parameterised-clients/t_server.py
@@ -1,0 +1,34 @@
+import sys
+
+from lsprotocol.types import InitializeParams
+
+import pytest_lsp
+from pytest_lsp import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import client_capabilities
+
+
+@pytest_lsp.fixture(
+    params=["neovim", "visual_studio_code"],
+    config=ClientServerConfig(server_command=[sys.executable, "server.py"]),
+)
+async def client(request, lsp_client: LanguageClient):
+    # Setup
+    params = InitializeParams(capabilities=client_capabilities(request.param))
+    await lsp_client.initialize(params)
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown()
+
+
+async def test_completions(client: LanguageClient):
+    """Ensure that the server implements completions correctly."""
+
+    results = await client.completion_request(
+        uri="file:///path/to/file.txt", line=1, character=0
+    )
+
+    labels = [item.label for item in results]
+    assert labels == ["hello", "world"]

--- a/lib/pytest-lsp/tests/examples/window-log-message-fail/t_server.py
+++ b/lib/pytest-lsp/tests/examples/window-log-message-fail/t_server.py
@@ -4,8 +4,8 @@ from lsprotocol.types import ClientCapabilities
 from lsprotocol.types import InitializeParams
 
 import pytest_lsp
-from pytest_lsp.client import LanguageClient
-from pytest_lsp.plugin import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import ClientServerConfig
 
 
 @pytest_lsp.fixture(

--- a/lib/pytest-lsp/tests/examples/window-log-message/t_server.py
+++ b/lib/pytest-lsp/tests/examples/window-log-message/t_server.py
@@ -4,8 +4,8 @@ from lsprotocol.types import ClientCapabilities
 from lsprotocol.types import InitializeParams
 
 import pytest_lsp
-from pytest_lsp.client import LanguageClient
-from pytest_lsp.plugin import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import ClientServerConfig
 
 
 @pytest_lsp.fixture(

--- a/lib/pytest-lsp/tests/examples/window-show-document/t_server.py
+++ b/lib/pytest-lsp/tests/examples/window-show-document/t_server.py
@@ -4,8 +4,8 @@ from lsprotocol.types import ClientCapabilities
 from lsprotocol.types import InitializeParams
 
 import pytest_lsp
-from pytest_lsp.client import LanguageClient
-from pytest_lsp.plugin import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import ClientServerConfig
 
 
 @pytest_lsp.fixture(

--- a/lib/pytest-lsp/tests/examples/window-show-message/t_server.py
+++ b/lib/pytest-lsp/tests/examples/window-show-message/t_server.py
@@ -4,8 +4,8 @@ from lsprotocol.types import ClientCapabilities
 from lsprotocol.types import InitializeParams
 
 import pytest_lsp
-from pytest_lsp.client import LanguageClient
-from pytest_lsp.plugin import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import ClientServerConfig
 
 
 @pytest_lsp.fixture(

--- a/lib/pytest-lsp/tests/test_examples.py
+++ b/lib/pytest-lsp/tests/test_examples.py
@@ -23,22 +23,23 @@ asyncio_mode = auto
 
 
 @pytest.mark.parametrize(
-    "name",
+    "name, expected",
     [
-        "diagnostics",
-        "getting-started",
-        "window-log-message",
-        "window-show-document",
-        "window-show-message",
+        ("diagnostics", dict(passed=1)),
+        ("getting-started", dict(passed=1)),
+        ("parameterised-clients", dict(passed=2)),
+        ("window-log-message", dict(passed=1)),
+        ("window-show-document", dict(passed=1)),
+        ("window-show-message", dict(passed=1)),
     ],
 )
-def test_documentation_examples(pytester: pytest.Pytester, name: str):
+def test_documentation_examples(pytester: pytest.Pytester, name: str, expected: dict):
     """Ensure that the examples included in the documentation work as expected."""
 
     setup_test(pytester, name)
 
     results = pytester.runpytest()
-    results.assert_outcomes(passed=1)
+    results.assert_outcomes(**expected)
 
 
 def test_getting_started_fail(pytester: pytest.Pytester):


### PR DESCRIPTION
This is now done by relying on pytest's standard fixture parameterisation support and passing through the `request` object to the user's fixture function