### PR TITLE
Swap the relationship between the agent's client and server 

### DIFF
--- a/lib/lsp-devtools/changes/17.fix.rst
+++ b/lib/lsp-devtools/changes/17.fix.rst
@@ -1,0 +1,1 @@
+The ``lsp-devtools agent`` command no longer fails to exit once an LSP session closes.

--- a/lib/lsp-devtools/changes/28.fix.rst
+++ b/lib/lsp-devtools/changes/28.fix.rst
@@ -1,0 +1,1 @@
+``lsp-devtools record`` no longer emits a ``ResourceWarning``

--- a/lib/lsp-devtools/changes/29.fix.rst
+++ b/lib/lsp-devtools/changes/29.fix.rst
@@ -1,0 +1,1 @@
+As a consequence of the new architecture, commands like ``lsp-devtools record`` no longer miss the start of an LSP session

--- a/lib/lsp-devtools/changes/37.misc.rst
+++ b/lib/lsp-devtools/changes/37.misc.rst
@@ -1,0 +1,1 @@
+The ``lsp-devtools agent`` now uses a TCP connection, which should make distribution easier

--- a/lib/lsp-devtools/changes/38.fix.rst
+++ b/lib/lsp-devtools/changes/38.fix.rst
@@ -1,0 +1,1 @@
+``lsp-devtools agent`` no longer emits ``Unable to send data, no available transport!`` messages

--- a/lib/lsp-devtools/lsp_devtools/agent/client.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/client.py
@@ -1,19 +1,13 @@
 import asyncio
-import json
-import re
-from json.decoder import JSONDecodeError
-from threading import Event
 from typing import Any
-from typing import Callable
 from typing import Optional
 
-import websockets
+from pygls.client import Client
+from pygls.client import aio_readline
 from pygls.protocol import default_converter
-from pygls.server import Server
 from websockets.client import WebSocketClientProtocol
 
 from lsp_devtools.agent.protocol import AgentProtocol
-from lsp_devtools.agent.protocol import MessageText
 
 
 class WebSocketClientTransportAdapter:
@@ -33,62 +27,15 @@ class WebSocketClientTransportAdapter:
         asyncio.ensure_future(self._ws.send(data))
 
 
-MESSAGE_PATTERN = re.compile(
-    r"^(?:[^\r\n]+\r\n)*"
-    + r"Content-Length: (?P<length>\d+)\r\n"
-    + r"(?:[^\r\n]+\r\n)*\r\n"
-    + r"(?P<body>{.*)",
-    re.DOTALL,
-)
+class AgentClient(Client):
+    """Client for connecting to an AgentServer instance."""
 
-
-def parse_rpc_message(
-    ls: "AgentClient", message: MessageText, callback: Callable[[dict], None]
-):
-    """Parse json-rpc messages coming from the agent.
-
-    Originally adatped from the ``data_received`` method on pygls' ``JsonRPCProtocol``
-    class.
-    """
-    data = message.text
-    message_buf = ls._client_buf if message.source == "client" else ls._server_buf
-
-    while len(data):
-        # Append the incoming chunk to the message buffer
-        message_buf.append(data)
-
-        # Look for the body of the message
-        msg = "".join(message_buf)
-        found = MESSAGE_PATTERN.fullmatch(msg)
-
-        body = found.group("body") if found else ""
-        length = int(found.group("length")) if found else 1
-
-        if len(body) < length:
-            # Message is incomplete; bail until more data arrives
-            return
-
-        # Message is complete;
-        # extract the body and any remaining data,
-        # and reset the buffer for the next message
-        body, data = body[:length], body[length:]
-        message_buf.clear()
-
-        callback(json.loads(body))
-
-
-class AgentClient(Server):
-    """Client for connecting to an LSPAgent instance."""
-
-    lsp: AgentProtocol
+    protocol: AgentProtocol
 
     def __init__(self):
         super().__init__(
             protocol_cls=AgentProtocol, converter_factory=default_converter
         )
-        self._client_buf = []
-        self._server_buf = []
-        self._stop_event: Event = Event()
 
     def _report_server_error(self, error, source):
         # Bail on error
@@ -96,50 +43,59 @@ class AgentClient(Server):
         self._stop_event.set()
 
     def feature(self, feature_name: str, options: Optional[Any] = None):
-        return self.lsp.fm.feature(feature_name, options)
+        return self.protocol.fm.feature(feature_name, options)
 
-    def start_ws_client(self, host: str, port: int):
-        """Similar to ``start_ws``, but where we create a client connection rather than
-        host a server."""
+    # TODO: Upstream this... or at least something equivalent.
+    async def start_tcp(self, host: str, port: int):
+        reader, writer = await asyncio.open_connection(host, port)
 
-        self.lsp._send_only_body = True  # Don't send headers within the payload
+        # adapter = TCPTransportAdapter(writer)
+        self.protocol.connection_made(writer)
+        connection = asyncio.create_task(
+            aio_readline(self._stop_event, reader, self.protocol.data_received)
+        )
+        self._async_tasks.append(connection)
 
-        async def client_connection(host: str, port: int):
-            """Create and run a client connection."""
+    # TODO: Upstream this... or at least something equivalent.
+    # def start_ws(self, host: str, port: int):
+    #     self.protocol._send_only_body = True  # Don't send headers within the payload
 
-            self._client = await websockets.connect(  # type: ignore
-                f"ws://{host}:{port}"
-            )
-            self.lsp.transport = WebSocketClientTransportAdapter(
-                self._client, self.loop
-            )
-            message = None
+    #     async def client_connection(host: str, port: int):
+    #         """Create and run a client connection."""
 
-            try:
-                while not self._stop_event.is_set():
-                    try:
-                        message = await asyncio.wait_for(
-                            self._client.recv(), timeout=0.5
-                        )
-                        self.lsp._procedure_handler(
-                            json.loads(
-                                message, object_hook=self.lsp._deserialize_message
-                            )
-                        )
-                    except JSONDecodeError:
-                        print(message or "-- message not found --")
-                        raise
-                    except TimeoutError:
-                        pass
-                    except Exception:
-                        raise
+    #         self._client = await websockets.connect(  # type: ignore
+    #             f"ws://{host}:{port}"
+    #         )
+    #         loop = asyncio.get_running_loop()
+    #         self.protocol.transport = WebSocketClientTransportAdapter(
+    #             self._client, loop
+    #         )
+    #         message = None
 
-            finally:
-                await self._client.close()
+    #         try:
+    #             while not self._stop_event.is_set():
+    #                 try:
+    #                     message = await asyncio.wait_for(
+    #                         self._client.recv(), timeout=0.5
+    #                     )
+    #                     self.protocol._procedure_handler(
+    #                         json.loads(
+    #                             message,
+    #                             object_hook=self.protocol._deserialize_message
+    #                         )
+    #                     )
+    #                 except JSONDecodeError:
+    #                     print(message or "-- message not found --")
+    #                     raise
+    #                 except TimeoutError:
+    #                     pass
+    #                 except Exception:
+    #                     raise
 
-        try:
-            asyncio.run(client_connection(host, port))
-        except KeyboardInterrupt:
-            pass
-        finally:
-            self.shutdown()
+    #         finally:
+    #             await self._client.close()
+
+    #     try:
+    #         asyncio.run(client_connection(host, port))
+    #     except KeyboardInterrupt:
+    #         pass

--- a/lib/lsp-devtools/lsp_devtools/agent/server.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/server.py
@@ -1,12 +1,19 @@
+import json
+import re
+from typing import Any
+from typing import Callable
+from typing import Optional
+
 from pygls.protocol import default_converter
 from pygls.server import Server
 
 from lsp_devtools.agent.protocol import AgentProtocol
+from lsp_devtools.agent.protocol import MessageText
 
 
 class AgentServer(Server):
-    """A pygls server that wraps an agent allowing other processes to interact with it
-    via websockets."""
+    """A pygls server that accepts connections from agents allowing them to send their
+    collected messages."""
 
     lsp: AgentProtocol
 
@@ -18,3 +25,52 @@ class AgentServer(Server):
             kwargs["converter_factory"] = default_converter
 
         super().__init__(*args, **kwargs)
+        self._client_buffer = []
+        self._server_buffer = []
+
+    def feature(self, feature_name: str, options: Optional[Any] = None):
+        return self.lsp.fm.feature(feature_name, options)
+
+
+MESSAGE_PATTERN = re.compile(
+    r"^(?:[^\r\n]+\r\n)*"
+    + r"Content-Length: (?P<length>\d+)\r\n"
+    + r"(?:[^\r\n]+\r\n)*\r\n"
+    + r"(?P<body>{.*)",
+    re.DOTALL,
+)
+
+
+def parse_rpc_message(
+    ls: AgentServer, message: MessageText, callback: Callable[[dict], None]
+):
+    """Parse json-rpc messages coming from the agent.
+
+    Originally adatped from the ``data_received`` method on pygls' ``JsonRPCProtocol``
+    class.
+    """
+    data = message.text
+    message_buf = ls._client_buffer if message.source == "client" else ls._server_buffer
+
+    while len(data):
+        # Append the incoming chunk to the message buffer
+        message_buf.append(data)
+
+        # Look for the body of the message
+        msg = "".join(message_buf)
+        found = MESSAGE_PATTERN.fullmatch(msg)
+
+        body = found.group("body") if found else ""
+        length = int(found.group("length")) if found else 1
+
+        if len(body) < length:
+            # Message is incomplete; bail until more data arrives
+            return
+
+        # Message is complete;
+        # extract the body and any remaining data,
+        # and reset the buffer for the next message
+        body, data = body[:length], body[length:]
+        message_buf.clear()
+
+        callback(json.loads(body))

--- a/lib/lsp-devtools/lsp_devtools/record/filters.py
+++ b/lib/lsp-devtools/lsp_devtools/record/filters.py
@@ -78,6 +78,7 @@ class LSPFilter(logging.Filter):
         if self.formatter.pattern:
             try:
                 record.msg = self.formatter.format(message)
+                record.args = None
             except Exception:
                 logger.debug(
                     "Skipping message that failed to format: %s", message, exc_info=True

--- a/lib/lsp-devtools/pyproject.toml
+++ b/lib/lsp-devtools/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "appdirs",
     "aiosqlite",
     "importlib-resources; python_version<\"3.9\"",
-    "pygls[ws]",
+    "pygls",
     "textual>=0.14.0",
     "typing-extensions; python_version<\"3.8\"",
 ]

--- a/lib/lsp-devtools/tests/record/test_filters.py
+++ b/lib/lsp-devtools/tests/record/test_filters.py
@@ -384,7 +384,5 @@ def test_filter_format_message():
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", request, None)
     record.__dict__["source"] = "client"
 
-    lsp.filter(record)
     assert lsp.filter(record) is True
-
     assert record.msg == "file:///path/to/file.txt"


### PR DESCRIPTION
Originally, the assumption was that the lsp agent would host a server
that commands like `lsp-devtools record` and `lsp-devtools tui`
would connect to.

However this posed a number of issues, such as commands like `record`
missing the beginning of a session since the agent would not wait for
a connection (Closes #29) as well as the agent not stopping once an LSP
session ended (Closes #17)

So this commit reverses that relationship, with commands like
``record`` spinning up the server and the lsp agent creating a client
connection.

Additionally this PR
- Switches to using the base `Client` provided by a *future version* of
  `pygls`
- Trials using async stdin/stdout streams for the agent - a potential
  candidate someday for upstreaming into `pygls`
- Switches to using a TCP connection between client and server. (Closes #37)
- Aligns the `lsp-devtools record` command to use the new architecture (Closes #28, Closes #38)

