### PR TITLE
Passthrough requested fixtures to user fixture func

### DIFF
--- a/.github/workflows/pytest-lsp-pr.yml
+++ b/.github/workflows/pytest-lsp-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
 
     steps:
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - run: |
         python --version
@@ -43,7 +44,7 @@ jobs:
         cd lib/pytest-lsp
 
         version=$(echo ${{ matrix.python-version }} | tr -d .)
-        python -m tox -e `tox -l | grep $version | tr '\n' ','`
+        python -m tox run -f "py${version}"
       name: Test
 
     - name: Package

--- a/docs/pytest-lsp/guide/fixtures.rst
+++ b/docs/pytest-lsp/guide/fixtures.rst
@@ -13,3 +13,14 @@ This can be used to run the same set of tests while pretending to be a different
    :language: python
    :start-at: @pytest_lsp.fixture
    :end-at: await lsp_client.shutdown_session()
+
+
+Requesting Other Fixtures
+-------------------------
+
+As you would expect, it's possible to request other fixtures to help set up your client.
+
+.. literalinclude:: ../../../lib/pytest-lsp/tests/examples/fixture-passthrough/t_server.py
+   :language: python
+   :start-at: @pytest.fixture
+   :end-at: await lsp_client.shutdown_session()

--- a/lib/pytest-lsp/.gitignore
+++ b/lib/pytest-lsp/.gitignore
@@ -1,0 +1,1 @@
+.coverage

--- a/lib/pytest-lsp/changes/71.enhancement.rst
+++ b/lib/pytest-lsp/changes/71.enhancement.rst
@@ -1,0 +1,1 @@
+Fixtures created with the `@pytest_lsp.fixture` decorator can now request additional pytest fixtures

--- a/lib/pytest-lsp/changes/75.misc.rst
+++ b/lib/pytest-lsp/changes/75.misc.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.7, add support for Python 3.12

--- a/lib/pytest-lsp/pyproject.toml
+++ b/lib/pytest-lsp/pyproject.toml
@@ -58,6 +58,14 @@ typecheck = [
 [tool.setuptools.packages.find]
 include = ["pytest_lsp*"]
 
+[tool.coverage.run]
+source_pkgs = ["pytest_lsp"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+sort = "Cover"
+
 [tool.isort]
 force_single_line = true
 profile = "black"
@@ -111,17 +119,3 @@ showcontent = true
 directory = "removed"
 name = "Removed"
 showcontent = true
-
-
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-isolated_build = True
-skip_missing_interpreters = true
-envlist = py{37,38,39,310,311}
-
-[testenv]
-extras= dev
-commands =
-    pytest {posargs}
-"""

--- a/lib/pytest-lsp/pyproject.toml
+++ b/lib/pytest-lsp/pyproject.toml
@@ -7,7 +7,7 @@ name = "pytest-lsp"
 version = "0.3.0"
 description = "pytest plugin for end-to-end testing of language servers"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [{ name = "Alex Carney", email = "alcarneyme@gmail.com" }]
 classifiers = [
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/lib/pytest-lsp/tests/examples/fixture-passthrough/server.py
+++ b/lib/pytest-lsp/tests/examples/fixture-passthrough/server.py
@@ -1,0 +1,18 @@
+from lsprotocol.types import TEXT_DOCUMENT_COMPLETION
+from lsprotocol.types import CompletionItem
+from lsprotocol.types import CompletionParams
+from pygls.server import LanguageServer
+
+server = LanguageServer("hello-world", "v1")
+
+
+@server.feature(TEXT_DOCUMENT_COMPLETION)
+def completion(ls: LanguageServer, params: CompletionParams):
+    return [
+        CompletionItem(label="hello"),
+        CompletionItem(label="world"),
+    ]
+
+
+if __name__ == "__main__":
+    server.start_io()

--- a/lib/pytest-lsp/tests/examples/fixture-passthrough/t_server.py
+++ b/lib/pytest-lsp/tests/examples/fixture-passthrough/t_server.py
@@ -1,0 +1,52 @@
+import sys
+
+import pytest
+from lsprotocol.types import CompletionList
+from lsprotocol.types import CompletionParams
+from lsprotocol.types import InitializeParams
+from lsprotocol.types import Position
+from lsprotocol.types import TextDocumentIdentifier
+
+import pytest_lsp
+from pytest_lsp import ClientServerConfig
+from pytest_lsp import LanguageClient
+from pytest_lsp import client_capabilities
+
+
+@pytest.fixture(scope="module")
+def client_name():
+    return "neovim"
+
+
+@pytest_lsp.fixture(
+    config=ClientServerConfig(server_command=[sys.executable, "server.py"]),
+)
+async def client(client_name: str, lsp_client: LanguageClient):
+    # Setup
+    params = InitializeParams(capabilities=client_capabilities(client_name))
+    await lsp_client.initialize_session(params)
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown_session()
+
+
+async def test_completions(client: LanguageClient):
+    """Ensure that the server implements completions correctly."""
+
+    results = await client.text_document_completion_async(
+        params=CompletionParams(
+            position=Position(line=1, character=0),
+            text_document=TextDocumentIdentifier(uri="file:///path/to/file.txt"),
+        )
+    )
+    assert results is not None
+
+    if isinstance(results, CompletionList):
+        items = results.items
+    else:
+        items = results
+
+    labels = [item.label for item in items]
+    assert labels == ["hello", "world"]

--- a/lib/pytest-lsp/tests/test_examples.py
+++ b/lib/pytest-lsp/tests/test_examples.py
@@ -27,6 +27,7 @@ asyncio_mode = auto
     [
         ("diagnostics", dict(passed=1)),
         ("getting-started", dict(passed=1)),
+        ("fixture-passthrough", dict(passed=1)),
         ("parameterised-clients", dict(passed=2)),
         ("window-log-message", dict(passed=1)),
         ("window-show-document", dict(passed=1)),

--- a/lib/pytest-lsp/tox.ini
+++ b/lib/pytest-lsp/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+isolated_build = true
+skip_missing_interpreters = true
+min_version = 4.0
+envlist = py{38,39,310,311,312}
+
+[testenv]
+description = "Run pytest-lsp's test suite"
+package = wheel
+wheel_build_env = .pkg
+deps =
+    coverage[toml]
+    git+https://github.com/openlawlibrary/pygls
+commands_pre =
+    coverage erase
+commands =
+    coverage run -m pytest {posargs}
+commands_post =
+    coverage report


### PR DESCRIPTION
- Fixtures created with the `@pytest_lsp.fixture` decorator can now request additional pytest fixtures
- Drop python 3.7, start testing against 3.12
- Refactor tox env definitions and enable coverage


Closes #71