### PR TITLE
Add Client Capability Index

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,12 @@
         "**/*.egg-info": true,
         "**/.pytest_cache": true,
         "**/.mypy_cache": true,
-    }
+    },
+    "esbonio.sphinx.buildCommand": [
+        "sphinx-build",
+        "-M",
+        "html",
+        "docs",
+        "docs/_build"
+    ],
 }

--- a/docs/capabilities/text-document.rst
+++ b/docs/capabilities/text-document.rst
@@ -1,0 +1,8 @@
+Text Document
+=============
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   text-document/*

--- a/docs/capabilities/text-document/code-action.rst
+++ b/docs/capabilities/text-document/code-action.rst
@@ -1,0 +1,29 @@
+``textDocument/codeAction``
+===========================
+
+Capabilities relating to the :lsp:`textDocument/codeAction` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.code_action.dynamic_registration
+
+Honors Change Annotations
+-------------------------
+
+.. capabilities:bool-table:: text_document.code_action.honors_change_annotations
+
+``CodeAction.isPreferred``
+--------------------------
+
+.. capabilities:bool-table:: text_document.code_action.is_preferred_support
+
+``CodeAction.disabled``
+-----------------------
+
+.. capabilities:bool-table:: text_document.code_action.disabled_support
+
+``CodeAction.data``
+-------------------
+
+.. capabilities:bool-table:: text_document.code_action.data_support

--- a/docs/capabilities/text-document/code-lens.rst
+++ b/docs/capabilities/text-document/code-lens.rst
@@ -1,0 +1,9 @@
+``textDocument/codeLens``
+=========================
+
+Capabilities relating to the :lsp:`textDocument/codeLens` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.code_lens.dynamic_registration

--- a/docs/capabilities/text-document/completion.rst
+++ b/docs/capabilities/text-document/completion.rst
@@ -1,0 +1,40 @@
+``textDocument/completion``
+===========================
+
+Dynamic Registration
+--------------------
+
+Capabilities relating to the :lsp:`textDocument/completion` request.
+
+.. capabilities:bool-table:: text_document.completion.dynamic_registration
+
+
+``CompletionItem.commitCharactersSupport``
+------------------------------------------
+
+.. capabilities:bool-table:: text_document.completion.completion_item.commit_characters_support
+
+``CompletionItem.deprecatedSupport``
+------------------------------------
+
+.. capabilities:bool-table:: text_document.completion.completion_item.deprecated_support
+
+``CompletionItem.insertReplaceSupport``
+---------------------------------------
+
+.. capabilities:bool-table:: text_document.completion.completion_item.insert_replace_support
+
+``CompletionItem.labelDetailsSupport``
+--------------------------------------
+
+.. capabilities:bool-table:: text_document.completion.completion_item.label_details_support
+
+``CompletionItem.preselectSupport``
+-----------------------------------
+
+.. capabilities:bool-table:: text_document.completion.completion_item.preselect_support
+
+``CompletionItem.snippetSupport``
+---------------------------------
+
+.. capabilities:bool-table:: text_document.completion.completion_item.snippet_support

--- a/docs/capabilities/text-document/declaration.rst
+++ b/docs/capabilities/text-document/declaration.rst
@@ -1,0 +1,14 @@
+``textDocument/declaration``
+============================
+
+Capabilities relating to the :lsp:`textDocument/declaration` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.declaration.dynamic_registration
+
+Link Support
+------------
+
+.. capabilities:bool-table:: text_document.declaration.link_support

--- a/docs/capabilities/text-document/definition.rst
+++ b/docs/capabilities/text-document/definition.rst
@@ -1,0 +1,14 @@
+``textDocument/definition``
+============================
+
+Capabilities relating to the :lsp:`textDocument/definition` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.definition.dynamic_registration
+
+Link Support
+------------
+
+.. capabilities:bool-table:: text_document.definition.link_support

--- a/docs/capabilities/text-document/diagnostic.rst
+++ b/docs/capabilities/text-document/diagnostic.rst
@@ -1,0 +1,14 @@
+``textDocument/diagnostic``
+===========================
+
+Capabilities relating to the :lsp:`textDocument/diagnostic` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.diagnostic.dynamic_registration
+
+Related Document Support
+------------------------
+
+.. capabilities:bool-table:: text_document.diagnostic.related_document_support

--- a/docs/capabilities/text-document/document-color.rst
+++ b/docs/capabilities/text-document/document-color.rst
@@ -1,0 +1,9 @@
+``textDocument/documentColor``
+==============================
+
+Capabilities relating to the :lsp:`textDocument/documentColor` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.color_provider.dynamic_registration

--- a/docs/capabilities/text-document/document-highlight.rst
+++ b/docs/capabilities/text-document/document-highlight.rst
@@ -1,0 +1,9 @@
+``textDocument/documentHighlight``
+==================================
+
+Capabilities relating to the :lsp:`textDocument/documentHighlight` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.document_highlight.dynamic_registration

--- a/docs/capabilities/text-document/document-link.rst
+++ b/docs/capabilities/text-document/document-link.rst
@@ -1,0 +1,14 @@
+``textDocument/documentLink``
+==================================
+
+Capabilities relating to the :lsp:`textDocument/documentLink` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.document_link.dynamic_registration
+
+Tooltip Support
+---------------
+
+.. capabilities:bool-table:: text_document.document_link.tooltip_support

--- a/docs/capabilities/text-document/document-symbols.rst
+++ b/docs/capabilities/text-document/document-symbols.rst
@@ -1,0 +1,19 @@
+``textDocument/documentSymbols``
+================================
+
+Capabilities relating to the :lsp:`textDocument/documentSymbols` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.document_symbol.dynamic_registration
+
+Hierarchical Symbols
+--------------------
+
+.. capabilities:bool-table:: text_document.document_symbol.hierarchical_document_symbol_support
+
+Label Support
+-------------
+
+.. capabilities:bool-table:: text_document.document_symbol.label_support

--- a/docs/capabilities/text-document/folding-range.rst
+++ b/docs/capabilities/text-document/folding-range.rst
@@ -1,0 +1,14 @@
+``textDocument/foldingRange``
+=============================
+
+Capabilities relating to the :lsp:`textDocument/foldingRange` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.folding_range.dynamic_registration
+
+Line Folding Only
+-----------------
+
+.. capabilities:bool-table:: text_document.folding_range.line_folding_only

--- a/docs/capabilities/text-document/formatting.rst
+++ b/docs/capabilities/text-document/formatting.rst
@@ -1,0 +1,9 @@
+``textDocument/formatting``
+=============================
+
+Capabilities relating to the :lsp:`textDocument/formatting` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.formatting.dynamic_registration

--- a/docs/capabilities/text-document/hover.rst
+++ b/docs/capabilities/text-document/hover.rst
@@ -1,0 +1,9 @@
+``textDocument/hover``
+======================
+
+Capabilities relating to the :lsp:`textDocument/hover` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.hover.dynamic_registration

--- a/docs/capabilities/text-document/implementation.rst
+++ b/docs/capabilities/text-document/implementation.rst
@@ -1,0 +1,14 @@
+``textDocument/implementation``
+===============================
+
+Capabilities relating to the :lsp:`textDocument/implementation` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.implementation.dynamic_registration
+
+Link Support
+------------
+
+.. capabilities:bool-table:: text_document.implementation.link_support

--- a/docs/capabilities/text-document/inlay-hint.rst
+++ b/docs/capabilities/text-document/inlay-hint.rst
@@ -1,0 +1,9 @@
+``textDocument/inlayHint``
+==========================
+
+Capabilities relating to the :lsp:`textDocument/inlayHint` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.inlay_hint.dynamic_registration

--- a/docs/capabilities/text-document/inline-value.rst
+++ b/docs/capabilities/text-document/inline-value.rst
@@ -1,0 +1,9 @@
+``textDocument/inlineValue``
+============================
+
+Capabilities relating to the :lsp:`textDocument/inlineValue` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.inline_value.dynamic_registration

--- a/docs/capabilities/text-document/linked-editing-range.rst
+++ b/docs/capabilities/text-document/linked-editing-range.rst
@@ -1,0 +1,9 @@
+``textDocument/linkedEditingRange``
+===================================
+
+Capabilities relating to the :lsp:`textDocument/linkedEditingRange` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.linked_editing_range.dynamic_registration

--- a/docs/capabilities/text-document/moniker.rst
+++ b/docs/capabilities/text-document/moniker.rst
@@ -1,0 +1,9 @@
+``textDocument/moniker``
+========================
+
+Capabilities relating to the :lsp:`textDocument/moniker` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.moniker.dynamic_registration

--- a/docs/capabilities/text-document/on-type-formatting.rst
+++ b/docs/capabilities/text-document/on-type-formatting.rst
@@ -1,0 +1,9 @@
+``textDocument/onTypeFormatting``
+=================================
+
+Capabilities relating to the :lsp:`textDocument/onTypeFormatting` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.on_type_formatting.dynamic_registration

--- a/docs/capabilities/text-document/preapare-call-hierachy.rst
+++ b/docs/capabilities/text-document/preapare-call-hierachy.rst
@@ -1,0 +1,9 @@
+``textDocument/prepareCallHierarchy``
+=====================================
+
+Capabilities relating to the :lsp:`textDocument/prepareCallHierarchy` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.call_hierarchy.dynamic_registration

--- a/docs/capabilities/text-document/preapare-type-hierachy.rst
+++ b/docs/capabilities/text-document/preapare-type-hierachy.rst
@@ -1,0 +1,9 @@
+``textDocument/prepareTypeHierarchy``
+=====================================
+
+Capabilities relating to the :lsp:`textDocument/prepareTypeHierarchy` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.type_hierarchy.dynamic_registration

--- a/docs/capabilities/text-document/publish-diagnostics.rst
+++ b/docs/capabilities/text-document/publish-diagnostics.rst
@@ -1,0 +1,24 @@
+``textDocument/publishDiagnostics``
+===================================
+
+Capabilities relating to the :lsp:`textDocument/publishDiagnostics` notification.
+
+Related Information
+-------------------
+
+.. capabilities:bool-table:: text_document.publish_diagnostics.related_information
+
+Version Support
+---------------
+
+.. capabilities:bool-table:: text_document.publish_diagnostics.version_support
+
+Code Description
+----------------
+
+.. capabilities:bool-table:: text_document.publish_diagnostics.code_description
+
+Data Support
+------------
+
+.. capabilities:bool-table:: text_document.publish_diagnostics.data_support

--- a/docs/capabilities/text-document/range-formatting.rst
+++ b/docs/capabilities/text-document/range-formatting.rst
@@ -1,0 +1,9 @@
+``textDocument/rangeFormatting``
+================================
+
+Capabilities relating to the :lsp:`textDocument/rangeFormatting` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.range_formatting.dynamic_registration

--- a/docs/capabilities/text-document/references.rst
+++ b/docs/capabilities/text-document/references.rst
@@ -1,0 +1,9 @@
+``textDocument/references``
+===============================
+
+Capabilities relating to the :lsp:`textDocument/references` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.references.dynamic_registration

--- a/docs/capabilities/text-document/rename.rst
+++ b/docs/capabilities/text-document/rename.rst
@@ -1,0 +1,19 @@
+``textDocument/rename``
+=======================
+
+Capabilities relating to the :lsp:`textDocument/rename` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.rename.dynamic_registration
+
+Prepare Support
+---------------
+
+.. capabilities:bool-table:: text_document.rename.prepare_support
+
+Honors Change Annotations
+-------------------------
+
+.. capabilities:bool-table:: text_document.rename.honors_change_annotations

--- a/docs/capabilities/text-document/selection-range.rst
+++ b/docs/capabilities/text-document/selection-range.rst
@@ -1,0 +1,9 @@
+``textDocument/selectionRange``
+===============================
+
+Capabilities relating to the :lsp:`textDocument/selectionRange` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.selection_range.dynamic_registration

--- a/docs/capabilities/text-document/semantic-tokens.rst
+++ b/docs/capabilities/text-document/semantic-tokens.rst
@@ -1,0 +1,45 @@
+``textDocument/semanticTokens``
+===============================
+
+Capabilities relating to :lsp:`textDocument/semanticTokens`.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.semantic_tokens.dynamic_registration
+
+``textDocument/semanticTokens/range``
+-------------------------------------
+
+.. capabilities:bool-table:: text_document.semantic_tokens.requests.range
+
+``textDocument/semanticTokens/full``
+-------------------------------------
+
+.. capabilities:bool-table:: text_document.semantic_tokens.requests.full
+
+``textDocument/semanticTokens/full/delta``
+------------------------------------------
+
+.. capabilities:bool-table:: text_document.semantic_tokens.requests.full.delta
+
+
+Overlapping Tokens
+------------------
+
+.. capabilities:bool-table:: text_document.semantic_tokens.overlapping_token_support
+
+Multiline Tokens
+----------------
+
+.. capabilities:bool-table:: text_document.semantic_tokens.multiline_token_support
+
+Server Cancel Support
+---------------------
+
+.. capabilities:bool-table:: text_document.semantic_tokens.server_cancel_support
+
+Augments Syntax Tokens
+----------------------
+
+.. capabilities:bool-table:: text_document.semantic_tokens.augments_syntax_tokens

--- a/docs/capabilities/text-document/signature-help.rst
+++ b/docs/capabilities/text-document/signature-help.rst
@@ -1,0 +1,24 @@
+``textDocument/signatureHelp``
+==============================
+
+Capabilities relating to the :lsp:`textDocument/signatureHelp` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.signature_help.dynamic_registration
+
+Label Offset Support
+--------------------
+
+.. capabilities:bool-table:: text_document.signature_help.signature_information.parameter_information.label_offset_support
+
+Active Parameter Support
+------------------------
+
+.. capabilities:bool-table:: text_document.signature_help.signature_information.active_parameter_support
+
+Context Support
+---------------
+
+.. capabilities:bool-table:: text_document.signature_help.context_support

--- a/docs/capabilities/text-document/type-definition.rst
+++ b/docs/capabilities/text-document/type-definition.rst
@@ -1,0 +1,14 @@
+``textDocument/typeDefinition``
+===============================
+
+Capabilities relating to the :lsp:`textDocument/typeDefinition` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: text_document.type_definition.dynamic_registration
+
+Link Support
+------------
+
+.. capabilities:bool-table:: text_document.type_definition.link_support

--- a/docs/capabilities/window.rst
+++ b/docs/capabilities/window.rst
@@ -1,0 +1,8 @@
+Window
+======
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   window/*

--- a/docs/capabilities/window/progress.rst
+++ b/docs/capabilities/window/progress.rst
@@ -1,0 +1,4 @@
+``window/workDoneProgress/create``
+==================================
+
+.. capabilities:bool-table:: window.work_done_progress

--- a/docs/capabilities/window/show-document.rst
+++ b/docs/capabilities/window/show-document.rst
@@ -1,0 +1,6 @@
+``window/showDocument``
+=======================
+
+Capabilities relating to the :lsp:`window/showDocument` request.
+
+.. capabilities:bool-table:: window.show_document.support

--- a/docs/capabilities/window/show-message.rst
+++ b/docs/capabilities/window/show-message.rst
@@ -1,0 +1,9 @@
+``window/showMessageRequest``
+=============================
+
+Capabilities relating to the :lsp:`window/showMessageRequest` request.
+
+Additional Properties Support
+-----------------------------
+
+.. capabilities:bool-table:: window.show_message.message_action_item.additional_properties_support

--- a/docs/capabilities/workspace.rst
+++ b/docs/capabilities/workspace.rst
@@ -1,0 +1,8 @@
+Workspace
+=========
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   workspace/*

--- a/docs/capabilities/workspace/apply-edit.rst
+++ b/docs/capabilities/workspace/apply-edit.rst
@@ -1,0 +1,6 @@
+``workspace/applyEdit``
+=======================
+
+Capabilities relating to the :lsp:`workspace/applyEdit` request.
+
+.. capabilities:bool-table:: workspace.apply_edit

--- a/docs/capabilities/workspace/code-lens-refresh.rst
+++ b/docs/capabilities/workspace/code-lens-refresh.rst
@@ -1,0 +1,9 @@
+``workspace/codeLens/refresh``
+==============================
+
+Capabilities relating to the :lsp:`workspace/codeLens/refresh` request.
+
+Refresh Support
+---------------
+
+.. capabilities:bool-table:: workspace.code_lens.refresh_support

--- a/docs/capabilities/workspace/configuration.rst
+++ b/docs/capabilities/workspace/configuration.rst
@@ -1,0 +1,16 @@
+``workspace/configuration``
+===========================
+
+Capabilities relating to the :lsp:`workspace/configuration` request.
+
+.. capabilities:bool-table:: workspace.configuration
+
+``workspace/didChangeConfiguration``
+====================================
+
+Capabilities relating to the :lsp:`workspace/didChangeConfiguration` notification.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: workspace.did_change_configuration.dynamic_registration

--- a/docs/capabilities/workspace/executeCommand.rst
+++ b/docs/capabilities/workspace/executeCommand.rst
@@ -1,0 +1,6 @@
+``workspace/executeCommand``
+============================
+
+Capabilities relating to the :lsp:`workspace/executeCommand` request.
+
+.. capabilities:bool-table:: workspace.execute_command.dynamic_registration

--- a/docs/capabilities/workspace/file-operations.rst
+++ b/docs/capabilities/workspace/file-operations.rst
@@ -1,0 +1,56 @@
+``workspace/willCreateFiles``
+=============================
+
+Capabilities relating to the :lsp:`workspace/willCreateFiles` request.
+
+.. capabilities:bool-table:: workspace.file_operations.will_create
+
+``workspace/didCreateFiles``
+=============================
+
+Capabilities relating to the :lsp:`workspace/didCreateFiles` notification.
+
+.. capabilities:bool-table:: workspace.file_operations.did_create
+
+``workspace/willRenameFiles``
+=============================
+
+Capabilities relating to the :lsp:`workspace/willRenameFiles` request.
+
+.. capabilities:bool-table:: workspace.file_operations.will_rename
+
+``workspace/didRenameFiles``
+=============================
+
+Capabilities relating to the :lsp:`workspace/didRenameFiles` notification.
+
+.. capabilities:bool-table:: workspace.file_operations.did_rename
+
+``workspace/willDeleteFiles``
+=============================
+
+Capabilities relating to the :lsp:`workspace/willDeleteFiles` request.
+
+.. capabilities:bool-table:: workspace.file_operations.will_delete
+
+``workspace/didDeleteFiles``
+=============================
+
+Capabilities relating to the :lsp:`workspace/didDeleteFiles` notification.
+
+.. capabilities:bool-table:: workspace.file_operations.did_delete
+
+``workspace/didChangeWatchedFiles``
+===================================
+
+Capabilities relating to the :lsp:`workspace/didChangeWatchedFiles` notification.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: workspace.did_change_watched_files.dynamic_registration
+
+Relative Pattern Support
+------------------------
+
+.. capabilities:bool-table:: workspace.did_change_watched_files.relative_pattern_support

--- a/docs/capabilities/workspace/inlay-hint-refresh.rst
+++ b/docs/capabilities/workspace/inlay-hint-refresh.rst
@@ -1,0 +1,9 @@
+``workspace/inlayHint/refresh``
+===============================
+
+Capabilities relating to the :lsp:`workspace/inlayHint/refresh` request.
+
+Refresh Support
+---------------
+
+.. capabilities:bool-table:: workspace.inlay_hint.refresh_support

--- a/docs/capabilities/workspace/inline-value-refresh.rst
+++ b/docs/capabilities/workspace/inline-value-refresh.rst
@@ -1,0 +1,9 @@
+``workspace/inlineValue/refresh``
+=================================
+
+Capabilities relating to the :lsp:`workspace/inlineValue/refresh` request.
+
+Rehresh Support
+---------------
+
+.. capabilities:bool-table:: workspace.inline_value.refresh_support

--- a/docs/capabilities/workspace/symbol.rst
+++ b/docs/capabilities/workspace/symbol.rst
@@ -1,0 +1,9 @@
+``workspace/symbol``
+====================
+
+Capabilities relating to the :lsp:`workspace/symbol` request.
+
+Dynamic Registration
+--------------------
+
+.. capabilities:bool-table:: workspace.symbol.dynamic_registration

--- a/docs/capabilities/workspace/workspace-folders.rst
+++ b/docs/capabilities/workspace/workspace-folders.rst
@@ -1,0 +1,6 @@
+``workspace/workspaceFolders``
+==============================
+
+Capabilities relating to the :lsp:`workspace/workspaceFolders` request.
+
+.. capabilities:bool-table:: workspace.workspace_folders

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,11 +24,15 @@ author = "Alex Carney"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    # built-in extensions
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
+    # 3rd party extensions
     "sphinx_copybutton",
     "sphinx_design",
+    # local extensions
+    "capabilities",
     "supported_clients",
 ]
 

--- a/docs/ext/capabilities.py
+++ b/docs/ext/capabilities.py
@@ -1,0 +1,238 @@
+import importlib.resources as resources
+import json
+import pathlib
+import re
+import typing
+from typing import List
+
+import attrs
+from docutils import nodes
+from docutils.parsers.rst import directives
+from lsprotocol import types
+from lsprotocol.converters import get_converter
+from pygls.capabilities import get_capability
+from sphinx.application import Sphinx
+from sphinx.domains import Domain
+from sphinx.pycode import ModuleAnalyzer
+from sphinx.util.docutils import SphinxDirective
+
+
+class BoolTable(SphinxDirective):
+    """Given a boolean capability, indicate the support across known clients and
+    versions"""
+
+    required_arguments = 1
+
+    option_spec = {
+        "caption": directives.unchanged,
+    }
+
+    def build_header(self):
+        columns = ["Client", "Supported Since"]
+        colspecs = [nodes.colspec("", colwidth="1") for _ in range(len(columns))]
+        header = nodes.thead(
+            "",
+            nodes.row("", *[nodes.entry("", nodes.Text(col)) for col in columns]),
+        )
+
+        return header, colspecs
+
+    def build_body(self, capability: str):
+        rows = []
+        domain = self.env.domains["capabilities"]
+
+        for (name, version), capabilities in domain.clients.items():
+            supported = get_capability(capabilities, capability, False)
+            rows.append(
+                nodes.row(
+                    "",
+                    nodes.entry("", nodes.Text(name)),
+                    nodes.entry(
+                        "",
+                        nodes.Text(version if supported else " - "),
+                        classes=["centered"],
+                    ),
+                )
+            )
+
+        return nodes.tbody("", *rows)
+
+    def run(self):
+        domain = self.env.domains["capabilities"]
+
+        capability = self.arguments[0]
+        if len(documentation := domain.get_capability_documentation(capability)) > 0:
+            self.state_machine.insert_input(documentation, "<lsprotocol.types>")
+
+        header, colspecs = self.build_header()
+        body = self.build_body(capability)
+
+        table = nodes.table("", nodes.tgroup("", *colspecs, header, body))
+
+        if (caption := self.options.get("caption", None)) is not None:
+            table.insert(0, nodes.title("", caption))
+
+        paragraph = nodes.paragraph(
+            "",
+            nodes.Text("Capability: "),
+            nodes.literal("", to_camel_case(capability)),
+        )
+
+        return [table, paragraph]
+
+
+def to_camel_case(snake_text: str) -> str:
+    """Convert snake_case to camelCase"""
+    first, *remaining = snake_text.split("_")
+    return first + "".join([text[0].upper() + text[1:] for text in remaining])
+
+
+def _load_clients():
+    """Load client capability data from pytest_lsp"""
+    clients = {}
+    converter = get_converter()
+
+    for resource in resources.files("pytest_lsp.clients").iterdir():
+        if not resource.name.endswith(".json"):
+            continue
+
+        capabilities = json.loads(pathlib.Path(resource).read_text())
+        params = converter.structure(capabilities, types.InitializeParams)
+
+        name = params.client_info.name
+        version = params.client_info.version
+
+        clients[(name, version)] = params.capabilities
+
+    return clients
+
+
+CODE_FENCE_PATTERN = re.compile(r"```(\w+)?")
+LINK_PATTERN = re.compile(r"\{@link ([^}]+)\}")
+LITERAL_PATTERN = re.compile(r"(?<![`:])`([^`]+)`(?!_)")
+MD_LINK_PATTERN = re.compile(r"\[`?([^\]]+?)`?\]\(([^)]+)\)")
+SINCE_PATTERN = re.compile(r"@since ([\d\.]+)")
+
+
+def process_docstring(lines):
+    """Fixup LSP docstrings so that they work with reStructuredText syntax
+
+    - Replaces ``@since <version>`` with ``**LSP v<version>**``
+
+    - Replaces ``{@link <item>}`` with ``:class:`~lsprotocol.types.<item>` ``
+
+    - Replaces markdown hyperlink with reStructuredText equivalent
+
+    - Replaces inline markdown code (single "`") with reStructuredText inline code
+      (double "`")
+
+    - Inserts the required newline before a bulleted list
+
+    - Replaces code fences with code blocks
+
+    - Fixes indentation
+    """
+
+    line_breaks = []
+    code_fences = []
+
+    for i, line in enumerate(lines):
+        if line.startswith("- "):
+            line_breaks.append(i)
+
+        # Does the line need dedenting?
+        if line.startswith(" " * 4) and not lines[i - 1].startswith(" "):
+            # Be sure to modify the original list *and* the line the rest of the
+            # loop will use.
+            line = lines[i][4:]
+            lines[i] = line
+
+        if (match := SINCE_PATTERN.search(line)) is not None:
+            start, end = match.span()
+            lines[i] = "".join([line[:start], f"**LSP v{match.group(1)}**", line[end:]])
+
+        if (match := LINK_PATTERN.search(line)) is not None:
+            start, end = match.span()
+            item = match.group(1)
+
+            lines[i] = "".join(
+                [line[:start], f":class:`~pygls:lsprotocol.types.{item}`", line[end:]]
+            )
+
+        if (match := MD_LINK_PATTERN.search(line)) is not None:
+            start, end = match.span()
+            text = match.group(1)
+            target = match.group(2)
+
+            line = "".join([line[:start], f"`{text} <{target}>`__", line[end:]])
+            lines[i] = line
+
+        if (match := LITERAL_PATTERN.search(line)) is not None:
+            start, end = match.span()
+            lines[i] = "".join([line[:start], f"`{match.group(0)}` ", line[end:]])
+
+        if (match := CODE_FENCE_PATTERN.match(line)) is not None:
+            open_ = len(code_fences) % 2 == 0
+            lang = match.group(1) or ""
+
+            if open_:
+                code_fences.append((i, lang))
+                line_breaks.extend([i, i + 1])
+            else:
+                code_fences.append(i)
+
+    # Rewrite fenced code blocks
+    open_ = -1
+    for fence in code_fences:
+        if isinstance(fence, tuple):
+            open_ = fence[0] + 1
+            lines[fence[0]] = f".. code-block:: {fence[1]}"
+        else:
+            # Indent content
+            for j in range(open_, fence):
+                lines[j] = f"   {lines[j]}"
+
+            lines[fence] = ""
+
+    # Insert extra line breaks
+    for offset, line in enumerate(line_breaks):
+        lines.insert(line + offset, "")
+
+
+class CapabilitiesDomain(Domain):
+    name = "capabilities"
+
+    directives = {
+        "bool-table": BoolTable,
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.clients = _load_clients()
+        self.analyzer = ModuleAnalyzer.for_module("lsprotocol.types")
+        self.analyzer.analyze()
+
+    def get_capability_documentation(self, field_name: str) -> List[str]:
+        """Return the documentation associated with the given capability."""
+        type_ = types.ClientCapabilities
+        parent = type_.__name__
+
+        *parents, field = field_name.split(".")
+        for p in parents:
+            attr = attrs.fields_dict(type_)[p]
+
+            type_ = attr.type
+            if len(args := typing.get_args(type_)) > 0:
+                type_ = args[0]
+
+            parent = type_.__name__
+
+        lines = self.analyzer.attr_docs.get((parent, field), [])
+        process_docstring(lines)
+
+        return lines
+
+
+def setup(app: Sphinx):
+    app.add_domain(CapabilitiesDomain)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,57 @@
 LSP Devtools
 ============
 
-The LSP Devtools project provides a number of tools that aim to make the
-process of developing language servers and clients easier.
+The LSP Devtools project provides a number of tools for making the the
+process of developing language servers easier.
+
+Client Capability Index
+-----------------------
+
+.. warning::
+
+   This is still under construction.
+
+.. important::
+
+   This accuracy of this section entirely depends on the captured capabilities data that is `bundled <https://github.com/swyddfa/lsp-devtools/tree/develop/lib/pytest-lsp/pytest_lsp/clients>`__ with pytest-lsp.
+
+   Pull requests for corrections and new data welcome!
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: Capabilities
+
+   capabilities/text-document
+   capabilities/workspace
+   capabilities/window
+
+Inspired by `caniuse.com <https://canisue.com>`__ this provides information on which clients support which features of the `LSP Specification <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/>`__.
+
+.. grid:: 2
+   :gutter: 2
+
+   .. grid-item-card:: Text Document
+      :columns: 12
+      :link: /capabilities/text-document
+      :link-type: doc
+      :text-align: center
+
+      Capabilities for text document methods like completion, code actions and more.
+
+   .. grid-item-card:: Window
+      :link: /capabilities/window
+      :link-type: doc
+      :text-align: center
+
+      Work done progress, show document and message requests
+
+   .. grid-item-card:: Workspace
+      :link: /capabilities/workspace
+      :link-type: doc
+      :text-align: center
+
+      File operations, workspace folders and configuration
 
 lsp-devtools
 ------------
@@ -14,6 +63,8 @@ lsp-devtools
    lsp-devtools/guide
    lsp-devtools/changelog
 
+
+.. figure:: https://user-images.githubusercontent.com/2675694/273293510-e43fdc92-03dd-40c9-aaca-ddb5e526031a.png
 
 The `lsp-devtools <https://pypi.org/project/lsp-devtools>`_ package provides a collection of CLI utilities that help inspect and visualise the interactions between a language client and a server.
 

--- a/lib/lsp-devtools/CHANGES.rst
+++ b/lib/lsp-devtools/CHANGES.rst
@@ -46,6 +46,7 @@ Features
   It is now capable of live streaming messages sent between a client and server to stdout, plain text files or a SQLite database.
 
   It also offers a number of filters for selecting the messages you wish to record, as well as a (WIP!) format string syntax for controlling how messages are formatted. (`#26 <https://github.com/alcarney/lsp-devtools/issues/26>`_)
+
 - Add ``tui``command.
 
   A proof of concept devtools TUI implemented in textual, that live updates with the LSP messages sent between client and server!

--- a/lib/pytest-lsp/pytest_lsp/client.py
+++ b/lib/pytest-lsp/pytest_lsp/client.py
@@ -234,4 +234,5 @@ def client_capabilities(client_spec: str) -> types.ClientCapabilities:
 
     converter = get_converter()
     capabilities = json.loads(filename.read_text())
-    return converter.structure(capabilities, types.ClientCapabilities)
+    params = converter.structure(capabilities, types.InitializeParams)
+    return params.capabilities

--- a/lib/pytest-lsp/pytest_lsp/clients/neovim_v0.6.1.json
+++ b/lib/pytest-lsp/pytest_lsp/clients/neovim_v0.6.1.json
@@ -1,225 +1,231 @@
 {
-  "workspace": {
-    "applyEdit": true,
-    "workspaceEdit": {
-      "resourceOperations": [
-        "rename",
-        "create",
-        "delete"
-      ]
-    },
-    "symbol": {
-      "dynamicRegistration": false,
-      "symbolKind": {
-        "valueSet": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19,
-          20,
-          21,
-          22,
-          23,
-          24,
-          25,
-          26
-        ]
-      }
-    },
-    "workspaceFolders": true,
-    "configuration": true
+  "clientInfo": {
+    "name": "Neovim",
+    "version": "0.6.1"
   },
-  "textDocument": {
-    "synchronization": {
-      "dynamicRegistration": false,
-      "willSave": false,
-      "willSaveWaitUntil": false,
-      "didSave": true
-    },
-    "completion": {
-      "dynamicRegistration": false,
-      "completionItem": {
-        "snippetSupport": false,
-        "commitCharactersSupport": false,
-        "documentationFormat": [
-          "markdown",
-          "plaintext"
-        ],
-        "deprecatedSupport": false,
-        "preselectSupport": false
-      },
-      "completionItemKind": {
-        "valueSet": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19,
-          20,
-          21,
-          22,
-          23,
-          24,
-          25
+  "capabilities": {
+    "workspace": {
+      "applyEdit": true,
+      "workspaceEdit": {
+        "resourceOperations": [
+          "rename",
+          "create",
+          "delete"
         ]
       },
-      "contextSupport": false
-    },
-    "hover": {
-      "dynamicRegistration": false,
-      "contentFormat": [
-        "markdown",
-        "plaintext"
-      ]
-    },
-    "signatureHelp": {
-      "dynamicRegistration": false,
-      "signatureInformation": {
-        "documentationFormat": [
-          "markdown",
-          "plaintext"
-        ],
-        "parameterInformation": {
-          "labelOffsetSupport": true
-        },
-        "activeParameterSupport": true
-      }
-    },
-    "declaration": {
-      "linkSupport": true
-    },
-    "definition": {
-      "linkSupport": true
-    },
-    "typeDefinition": {
-      "linkSupport": true
-    },
-    "implementation": {
-      "linkSupport": true
-    },
-    "references": {
-      "dynamicRegistration": false
-    },
-    "documentHighlight": {
-      "dynamicRegistration": false
-    },
-    "documentSymbol": {
-      "dynamicRegistration": false,
-      "symbolKind": {
-        "valueSet": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19,
-          20,
-          21,
-          22,
-          23,
-          24,
-          25,
-          26
-        ]
-      },
-      "hierarchicalDocumentSymbolSupport": true
-    },
-    "codeAction": {
-      "dynamicRegistration": false,
-      "codeActionLiteralSupport": {
-        "codeActionKind": {
+      "symbol": {
+        "dynamicRegistration": false,
+        "symbolKind": {
           "valueSet": [
-            "",
-            "Empty",
-            "QuickFix",
-            "Refactor",
-            "RefactorExtract",
-            "RefactorInline",
-            "RefactorRewrite",
-            "Source",
-            "SourceOrganizeImports",
-            "quickfix",
-            "refactor",
-            "refactor.extract",
-            "refactor.inline",
-            "refactor.rewrite",
-            "source",
-            "source.organizeImports"
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26
           ]
         }
       },
-      "dataSupport": true,
-      "resolveSupport": {
-        "properties": [
-          "edit"
+      "workspaceFolders": true,
+      "configuration": true
+    },
+    "textDocument": {
+      "synchronization": {
+        "dynamicRegistration": false,
+        "willSave": false,
+        "willSaveWaitUntil": false,
+        "didSave": true
+      },
+      "completion": {
+        "dynamicRegistration": false,
+        "completionItem": {
+          "snippetSupport": false,
+          "commitCharactersSupport": false,
+          "documentationFormat": [
+            "markdown",
+            "plaintext"
+          ],
+          "deprecatedSupport": false,
+          "preselectSupport": false
+        },
+        "completionItemKind": {
+          "valueSet": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25
+          ]
+        },
+        "contextSupport": false
+      },
+      "hover": {
+        "dynamicRegistration": false,
+        "contentFormat": [
+          "markdown",
+          "plaintext"
         ]
+      },
+      "signatureHelp": {
+        "dynamicRegistration": false,
+        "signatureInformation": {
+          "documentationFormat": [
+            "markdown",
+            "plaintext"
+          ],
+          "parameterInformation": {
+            "labelOffsetSupport": true
+          },
+          "activeParameterSupport": true
+        }
+      },
+      "declaration": {
+        "linkSupport": true
+      },
+      "definition": {
+        "linkSupport": true
+      },
+      "typeDefinition": {
+        "linkSupport": true
+      },
+      "implementation": {
+        "linkSupport": true
+      },
+      "references": {
+        "dynamicRegistration": false
+      },
+      "documentHighlight": {
+        "dynamicRegistration": false
+      },
+      "documentSymbol": {
+        "dynamicRegistration": false,
+        "symbolKind": {
+          "valueSet": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26
+          ]
+        },
+        "hierarchicalDocumentSymbolSupport": true
+      },
+      "codeAction": {
+        "dynamicRegistration": false,
+        "codeActionLiteralSupport": {
+          "codeActionKind": {
+            "valueSet": [
+              "",
+              "Empty",
+              "QuickFix",
+              "Refactor",
+              "RefactorExtract",
+              "RefactorInline",
+              "RefactorRewrite",
+              "Source",
+              "SourceOrganizeImports",
+              "quickfix",
+              "refactor",
+              "refactor.extract",
+              "refactor.inline",
+              "refactor.rewrite",
+              "source",
+              "source.organizeImports"
+            ]
+          }
+        },
+        "dataSupport": true,
+        "resolveSupport": {
+          "properties": [
+            "edit"
+          ]
+        }
+      },
+      "rename": {
+        "dynamicRegistration": false,
+        "prepareSupport": true
+      },
+      "publishDiagnostics": {
+        "relatedInformation": true,
+        "tagSupport": {
+          "valueSet": [
+            1,
+            2
+          ]
+        }
       }
     },
-    "rename": {
-      "dynamicRegistration": false,
-      "prepareSupport": true
-    },
-    "publishDiagnostics": {
-      "relatedInformation": true,
-      "tagSupport": {
-        "valueSet": [
-          1,
-          2
-        ]
+    "window": {
+      "workDoneProgress": true,
+      "showMessage": {
+        "messageActionItem": {
+          "additionalPropertiesSupport": false
+        }
+      },
+      "showDocument": {
+        "support": false
       }
-    }
-  },
-  "window": {
-    "workDoneProgress": true,
-    "showMessage": {
-      "messageActionItem": {
-        "additionalPropertiesSupport": false
-      }
-    },
-    "showDocument": {
-      "support": false
     }
   }
 }

--- a/lib/pytest-lsp/pytest_lsp/clients/visual_studio_code_v1.65.2.json
+++ b/lib/pytest-lsp/pytest_lsp/clients/visual_studio_code_v1.65.2.json
@@ -1,383 +1,389 @@
 {
-  "workspace": {
-    "applyEdit": true,
-    "workspaceEdit": {
-      "documentChanges": true,
-      "resourceOperations": [
-        "create",
-        "rename",
-        "delete"
-      ],
-      "failureHandling": "textOnlyTransactional",
-      "normalizesLineEndings": true,
-      "changeAnnotationSupport": {
-        "groupsOnLabel": true
-      }
-    },
-    "didChangeConfiguration": {
-      "dynamicRegistration": true
-    },
-    "didChangeWatchedFiles": {
-      "dynamicRegistration": true
-    },
-    "symbol": {
-      "dynamicRegistration": true,
-      "symbolKind": {
-        "valueSet": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19,
-          20,
-          21,
-          22,
-          23,
-          24,
-          25,
-          26
-        ]
-      },
-      "tagSupport": {
-        "valueSet": [
-          1
-        ]
-      }
-    },
-    "executeCommand": {
-      "dynamicRegistration": true
-    },
-    "workspaceFolders": true,
-    "configuration": true,
-    "semanticTokens": {
-      "refreshSupport": true
-    },
-    "codeLens": {
-      "refreshSupport": true
-    },
-    "fileOperations": {
-      "dynamicRegistration": true,
-      "didCreate": true,
-      "willCreate": true,
-      "didRename": true,
-      "willRename": true,
-      "didDelete": true,
-      "willDelete": true
-    }
+  "clientInfo": {
+    "name": "Visual Studio Code",
+    "version": "1.65.2"
   },
-  "textDocument": {
-    "synchronization": {
-      "dynamicRegistration": true,
-      "willSave": true,
-      "willSaveWaitUntil": true,
-      "didSave": true
+  "capabilities": {
+    "workspace": {
+      "applyEdit": true,
+      "workspaceEdit": {
+        "documentChanges": true,
+        "resourceOperations": [
+          "create",
+          "rename",
+          "delete"
+        ],
+        "failureHandling": "textOnlyTransactional",
+        "normalizesLineEndings": true,
+        "changeAnnotationSupport": {
+          "groupsOnLabel": true
+        }
+      },
+      "didChangeConfiguration": {
+        "dynamicRegistration": true
+      },
+      "didChangeWatchedFiles": {
+        "dynamicRegistration": true
+      },
+      "symbol": {
+        "dynamicRegistration": true,
+        "symbolKind": {
+          "valueSet": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26
+          ]
+        },
+        "tagSupport": {
+          "valueSet": [
+            1
+          ]
+        }
+      },
+      "executeCommand": {
+        "dynamicRegistration": true
+      },
+      "workspaceFolders": true,
+      "configuration": true,
+      "semanticTokens": {
+        "refreshSupport": true
+      },
+      "codeLens": {
+        "refreshSupport": true
+      },
+      "fileOperations": {
+        "dynamicRegistration": true,
+        "didCreate": true,
+        "willCreate": true,
+        "didRename": true,
+        "willRename": true,
+        "didDelete": true,
+        "willDelete": true
+      }
     },
-    "completion": {
-      "dynamicRegistration": true,
-      "completionItem": {
-        "snippetSupport": true,
-        "commitCharactersSupport": true,
-        "documentationFormat": [
+    "textDocument": {
+      "synchronization": {
+        "dynamicRegistration": true,
+        "willSave": true,
+        "willSaveWaitUntil": true,
+        "didSave": true
+      },
+      "completion": {
+        "dynamicRegistration": true,
+        "completionItem": {
+          "snippetSupport": true,
+          "commitCharactersSupport": true,
+          "documentationFormat": [
+            "markdown",
+            "plaintext"
+          ],
+          "deprecatedSupport": true,
+          "preselectSupport": true,
+          "tagSupport": {
+            "valueSet": [
+              1
+            ]
+          },
+          "insertReplaceSupport": true,
+          "resolveSupport": {
+            "properties": [
+              "documentation",
+              "detail",
+              "additionalTextEdits"
+            ]
+          },
+          "insertTextModeSupport": {
+            "valueSet": [
+              1,
+              2
+            ]
+          }
+        },
+        "completionItemKind": {
+          "valueSet": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25
+          ]
+        },
+        "contextSupport": true
+      },
+      "hover": {
+        "dynamicRegistration": true,
+        "contentFormat": [
           "markdown",
           "plaintext"
-        ],
-        "deprecatedSupport": true,
-        "preselectSupport": true,
+        ]
+      },
+      "signatureHelp": {
+        "dynamicRegistration": true,
+        "signatureInformation": {
+          "documentationFormat": [
+            "markdown",
+            "plaintext"
+          ],
+          "parameterInformation": {
+            "labelOffsetSupport": true
+          },
+          "activeParameterSupport": true
+        },
+        "contextSupport": true
+      },
+      "declaration": {
+        "dynamicRegistration": true,
+        "linkSupport": true
+      },
+      "definition": {
+        "dynamicRegistration": true,
+        "linkSupport": true
+      },
+      "typeDefinition": {
+        "dynamicRegistration": true,
+        "linkSupport": true
+      },
+      "implementation": {
+        "dynamicRegistration": true,
+        "linkSupport": true
+      },
+      "references": {
+        "dynamicRegistration": true
+      },
+      "documentHighlight": {
+        "dynamicRegistration": true
+      },
+      "documentSymbol": {
+        "dynamicRegistration": true,
+        "symbolKind": {
+          "valueSet": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26
+          ]
+        },
+        "hierarchicalDocumentSymbolSupport": true,
         "tagSupport": {
           "valueSet": [
             1
           ]
         },
-        "insertReplaceSupport": true,
+        "labelSupport": true
+      },
+      "codeAction": {
+        "dynamicRegistration": true,
+        "codeActionLiteralSupport": {
+          "codeActionKind": {
+            "valueSet": [
+              "",
+              "quickfix",
+              "refactor",
+              "refactor.extract",
+              "refactor.inline",
+              "refactor.rewrite",
+              "source",
+              "source.organizeImports"
+            ]
+          }
+        },
+        "isPreferredSupport": true,
+        "disabledSupport": true,
+        "dataSupport": true,
         "resolveSupport": {
           "properties": [
-            "documentation",
-            "detail",
-            "additionalTextEdits"
+            "edit"
           ]
         },
-        "insertTextModeSupport": {
+        "honorsChangeAnnotations": false
+      },
+      "codeLens": {
+        "dynamicRegistration": true
+      },
+      "documentLink": {
+        "dynamicRegistration": true,
+        "tooltipSupport": true
+      },
+      "colorProvider": {
+        "dynamicRegistration": true
+      },
+      "formatting": {
+        "dynamicRegistration": true
+      },
+      "rangeFormatting": {
+        "dynamicRegistration": true
+      },
+      "onTypeFormatting": {
+        "dynamicRegistration": true
+      },
+      "rename": {
+        "dynamicRegistration": true,
+        "prepareSupport": true,
+        "prepareSupportDefaultBehavior": 1,
+        "honorsChangeAnnotations": true
+      },
+      "publishDiagnostics": {
+        "relatedInformation": true,
+        "tagSupport": {
           "valueSet": [
             1,
             2
           ]
-        }
-      },
-      "completionItemKind": {
-        "valueSet": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19,
-          20,
-          21,
-          22,
-          23,
-          24,
-          25
-        ]
-      },
-      "contextSupport": true
-    },
-    "hover": {
-      "dynamicRegistration": true,
-      "contentFormat": [
-        "markdown",
-        "plaintext"
-      ]
-    },
-    "signatureHelp": {
-      "dynamicRegistration": true,
-      "signatureInformation": {
-        "documentationFormat": [
-          "markdown",
-          "plaintext"
-        ],
-        "parameterInformation": {
-          "labelOffsetSupport": true
         },
-        "activeParameterSupport": true
+        "versionSupport": false,
+        "codeDescriptionSupport": true,
+        "dataSupport": true
       },
-      "contextSupport": true
-    },
-    "declaration": {
-      "dynamicRegistration": true,
-      "linkSupport": true
-    },
-    "definition": {
-      "dynamicRegistration": true,
-      "linkSupport": true
-    },
-    "typeDefinition": {
-      "dynamicRegistration": true,
-      "linkSupport": true
-    },
-    "implementation": {
-      "dynamicRegistration": true,
-      "linkSupport": true
-    },
-    "references": {
-      "dynamicRegistration": true
-    },
-    "documentHighlight": {
-      "dynamicRegistration": true
-    },
-    "documentSymbol": {
-      "dynamicRegistration": true,
-      "symbolKind": {
-        "valueSet": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19,
-          20,
-          21,
-          22,
-          23,
-          24,
-          25,
-          26
-        ]
+      "foldingRange": {
+        "dynamicRegistration": true,
+        "rangeLimit": 5000,
+        "lineFoldingOnly": true
       },
-      "hierarchicalDocumentSymbolSupport": true,
-      "tagSupport": {
-        "valueSet": [
-          1
-        ]
+      "selectionRange": {
+        "dynamicRegistration": true
       },
-      "labelSupport": true
-    },
-    "codeAction": {
-      "dynamicRegistration": true,
-      "codeActionLiteralSupport": {
-        "codeActionKind": {
-          "valueSet": [
-            "",
-            "quickfix",
-            "refactor",
-            "refactor.extract",
-            "refactor.inline",
-            "refactor.rewrite",
-            "source",
-            "source.organizeImports"
-          ]
-        }
+      "linkedEditingRange": {
+        "dynamicRegistration": true
       },
-      "isPreferredSupport": true,
-      "disabledSupport": true,
-      "dataSupport": true,
-      "resolveSupport": {
-        "properties": [
-          "edit"
-        ]
+      "callHierarchy": {
+        "dynamicRegistration": true
       },
-      "honorsChangeAnnotations": false
-    },
-    "codeLens": {
-      "dynamicRegistration": true
-    },
-    "documentLink": {
-      "dynamicRegistration": true,
-      "tooltipSupport": true
-    },
-    "colorProvider": {
-      "dynamicRegistration": true
-    },
-    "formatting": {
-      "dynamicRegistration": true
-    },
-    "rangeFormatting": {
-      "dynamicRegistration": true
-    },
-    "onTypeFormatting": {
-      "dynamicRegistration": true
-    },
-    "rename": {
-      "dynamicRegistration": true,
-      "prepareSupport": true,
-      "prepareSupportDefaultBehavior": 1,
-      "honorsChangeAnnotations": true
-    },
-    "publishDiagnostics": {
-      "relatedInformation": true,
-      "tagSupport": {
-        "valueSet": [
-          1,
-          2
-        ]
-      },
-      "versionSupport": false,
-      "codeDescriptionSupport": true,
-      "dataSupport": true
-    },
-    "foldingRange": {
-      "dynamicRegistration": true,
-      "rangeLimit": 5000,
-      "lineFoldingOnly": true
-    },
-    "selectionRange": {
-      "dynamicRegistration": true
-    },
-    "linkedEditingRange": {
-      "dynamicRegistration": true
-    },
-    "callHierarchy": {
-      "dynamicRegistration": true
-    },
-    "semanticTokens": {
-      "requests": {
-        "range": true,
-        "full": {
-          "delta": true
-        }
-      },
-      "tokenTypes": [
-        "namespace",
-        "type",
-        "class",
-        "enum",
-        "interface",
-        "struct",
-        "typeParameter",
-        "parameter",
-        "variable",
-        "property",
-        "enumMember",
-        "event",
-        "function",
-        "method",
-        "macro",
-        "keyword",
-        "modifier",
-        "comment",
-        "string",
-        "number",
-        "regexp",
-        "operator"
-      ],
-      "tokenModifiers": [
-        "declaration",
-        "definition",
-        "readonly",
-        "static",
-        "deprecated",
-        "abstract",
-        "async",
-        "modification",
-        "documentation",
-        "defaultLibrary"
-      ],
-      "formats": [
-        "relative"
-      ],
-      "overlappingTokenSupport": false,
-      "multilineTokenSupport": false,
-      "dynamicRegistration": true
-    }
-  },
-  "window": {
-    "workDoneProgress": true,
-    "showMessage": {
-      "messageActionItem": {
-        "additionalPropertiesSupport": true
+      "semanticTokens": {
+        "requests": {
+          "range": true,
+          "full": {
+            "delta": true
+          }
+        },
+        "tokenTypes": [
+          "namespace",
+          "type",
+          "class",
+          "enum",
+          "interface",
+          "struct",
+          "typeParameter",
+          "parameter",
+          "variable",
+          "property",
+          "enumMember",
+          "event",
+          "function",
+          "method",
+          "macro",
+          "keyword",
+          "modifier",
+          "comment",
+          "string",
+          "number",
+          "regexp",
+          "operator"
+        ],
+        "tokenModifiers": [
+          "declaration",
+          "definition",
+          "readonly",
+          "static",
+          "deprecated",
+          "abstract",
+          "async",
+          "modification",
+          "documentation",
+          "defaultLibrary"
+        ],
+        "formats": [
+          "relative"
+        ],
+        "overlappingTokenSupport": false,
+        "multilineTokenSupport": false,
+        "dynamicRegistration": true
       }
     },
-    "showDocument": {
-      "support": true
-    }
-  },
-  "general": {
-    "regularExpressions": {
-      "engine": "ECMAScript",
-      "version": "ES2020"
+    "window": {
+      "workDoneProgress": true,
+      "showMessage": {
+        "messageActionItem": {
+          "additionalPropertiesSupport": true
+        }
+      },
+      "showDocument": {
+        "support": true
+      }
     },
-    "markdown": {
-      "parser": "marked",
-      "version": "1.1.0"
+    "general": {
+      "regularExpressions": {
+        "engine": "ECMAScript",
+        "version": "ES2020"
+      },
+      "markdown": {
+        "parser": "marked",
+        "version": "1.1.0"
+      }
     }
   }
 }

--- a/lib/pytest-lsp/tests/test_client.py
+++ b/lib/pytest-lsp/tests/test_client.py
@@ -5,7 +5,6 @@ import sys
 
 import pygls.uris as uri
 import pytest
-
 import pytest_lsp
 
 
@@ -32,7 +31,7 @@ def test_client_capabilities(
     clients_dir = pathlib.Path(pytest_lsp.__file__).parent / "clients"
     with (clients_dir / client_capabilities).open() as f:
         # Easiest way to reformat the JSON onto a single line
-        expected = json.dumps(json.load(f))
+        expected = json.dumps(json.load(f)["capabilities"])
 
     pytester.makeini(
         """


### PR DESCRIPTION

![Screenshot_20231018_222054](https://github.com/swyddfa/lsp-devtools/assets/2675694/f0a4a538-294a-4fd2-bc87-6497c7b0bad7)

Inspired by [caniuse.com](https://caniuse.com) this adds a section to the documentation that builds on the captured client capabilities in `pytest-lsp` to highlight which parts of the LSP specification are supported by which clients.

This is only a proof of concept with plenty to fix in the future

- Only `boolean` capability attributes are currently supported.
- Multiple versions of a client is not currently handled
- Reporting on the client version does not tell the whole story... e.g. VSCode itself might support inlay hints from version X, but `vscode-languageclient` must also be at version Y to enable it!
- Missing client data! - Pull requests welcome! :smile: 