### PR TITLE
`lsp-devtools` integration

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Client Capability Index
 .. toctree::
    :maxdepth: 2
    :hidden:
-   :caption: Capabilities
+   :caption: Client Capabilities
 
    capabilities/text-document
    capabilities/workspace

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,6 +78,7 @@ pytest-lsp
    :caption: pytest-lsp
 
    pytest-lsp/guide
+   pytest-lsp/howto
    pytest-lsp/reference
    pytest-lsp/changelog
 

--- a/docs/lsp-devtools/guide.rst
+++ b/docs/lsp-devtools/guide.rst
@@ -6,4 +6,4 @@ User Guide
 
    guide/getting-started
    guide/record-command
-   guide/tui-command
+   guide/inspect-command

--- a/docs/lsp-devtools/guide/getting-started.rst
+++ b/docs/lsp-devtools/guide/getting-started.rst
@@ -97,9 +97,9 @@ Currently ``lsp-devtools`` provides the following applications
 
    See :doc:`/lsp-devtools/guide/record-command` for details
 
-``lsp-devtools tui``
+``lsp-devtools inspect``
    An interactive terminal application, powered by `textual <https://pypi.org/project/textual>`_.
 
    .. figure:: /images/tui-screenshot.svg
 
-   See :doc:`/lsp-devtools/guide/tui-command` for details
+   See :doc:`/lsp-devtools/guide/inspect-command` for details

--- a/docs/lsp-devtools/guide/inspect-command.rst
+++ b/docs/lsp-devtools/guide/inspect-command.rst
@@ -1,0 +1,10 @@
+LSP Inspector
+=============
+
+.. figure:: /images/tui-screenshot.svg
+   :align: center
+
+   The ``lsp-devtools inspect`` command
+
+
+The ``lsp-devtools inspect`` command opens an application that allows you to browse all the messages sent between a client and server during an LSP session.

--- a/docs/lsp-devtools/guide/tui-command.rst
+++ b/docs/lsp-devtools/guide/tui-command.rst
@@ -1,2 +1,0 @@
-TUI Application
-===============

--- a/docs/pytest-lsp/guide.rst
+++ b/docs/pytest-lsp/guide.rst
@@ -9,4 +9,3 @@ User Guide
    guide/client-capabilities
    guide/fixtures
    guide/troubleshooting
-   guide/testing-json-rpc-servers

--- a/docs/pytest-lsp/howto.rst
+++ b/docs/pytest-lsp/howto.rst
@@ -1,0 +1,8 @@
+How To
+======
+
+.. toctree::
+   :maxdepth: 2
+
+   Integrate with lsp-devtools <howto/integrate-with-lsp-devtools>
+   Test Generic JSON-RPC Servers <howto/testing-json-rpc-servers>

--- a/docs/pytest-lsp/howto/integrate-with-lsp-devtools.rst
+++ b/docs/pytest-lsp/howto/integrate-with-lsp-devtools.rst
@@ -1,0 +1,22 @@
+How To Integrate ``pytest-lsp`` with ``lsp-devtools``
+=====================================================
+
+``pytest-lsp`` is able to forward LSP traffic to utilities like :doc:`lsp-devtools record </lsp-devtools/guide/record-command>` and :doc:`lsp-devtools inspect </lsp-devtools/guide/inspect-command>`
+
+.. important::
+
+   ``pytest-lsp`` does not depend on ``lsp-devtools`` directly and instead assumes that the ``lsp-devtools`` command is available on your ``$PATH``.
+   It's recommended to install ``lsp-devtools`` via `pipx <https://pypa.github.io/pipx/>`__::
+
+     $ pipx install lsp-devtools
+
+To enable the integration pass the ``--lsp-devtools`` flag to ``pytest``::
+
+  $ pytest --lsp-devtools
+
+This will make ``pytest-lsp`` send the captured traffic to an ``lsp-devtools`` command listening on ``localhost:8765`` by default.
+
+To change the default host and/or port number you can pass it to the ``--lsp-devtools`` cli option::
+
+  $ pytest --lsp-devtools 1234            # change port number
+  $ pytest --lsp-devtools 127.0.01:1234   # change host and port

--- a/docs/pytest-lsp/howto/testing-json-rpc-servers.rst
+++ b/docs/pytest-lsp/howto/testing-json-rpc-servers.rst
@@ -1,5 +1,5 @@
-Testing JSON-RPC Servers
-========================
+How To Test Generic JSON-RPC Servers
+====================================
 
 While ``pytest-lsp`` is primarily focused on writing tests for LSP servers it is possible to reuse some of the machinery to test other JSON-RPC servers.
 

--- a/lib/lsp-devtools/lsp_devtools/inspector/__init__.py
+++ b/lib/lsp-devtools/lsp_devtools/inspector/__init__.py
@@ -157,9 +157,8 @@ class LSPInspector(App):
     def __init__(self, db: Database, server: AgentServer, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        db.app = self
         self.db = db
-        """Where the data for the app is being held"""
+        db.app = self
 
         self.server = server
         """Server used to manage connections to lsp servers."""
@@ -193,9 +192,11 @@ class LSPInspector(App):
         self._async_tasks.append(
             asyncio.create_task(self.server.start_tcp("localhost", 8765))
         )
-        await self.update_table()
+        table = self.query_one(MessagesTable)
+        await table.update()
 
-    async def update_table(self):
+    @on(Database.Update)
+    async def update_table(self, event: Database.Update):
         table = self.query_one(MessagesTable)
         await table.update()
 
@@ -255,7 +256,7 @@ def setup_server(db: Database):
     return server
 
 
-def tui(args, extra: List[str]):
+def inspector(args, extra: List[str]):
     db = Database(args.dbpath)
     server = setup_server(db)
 
@@ -298,4 +299,4 @@ manipulate an LSP session interactively.
     connect.add_argument(
         "-p", "--port", type=int, default=8765, help="the port to connect to."
     )
-    cmd.set_defaults(run=tui)
+    cmd.set_defaults(run=inspector)

--- a/lib/pytest-lsp/changes/97.feature.rst
+++ b/lib/pytest-lsp/changes/97.feature.rst
@@ -1,0 +1,1 @@
+``pytest-lsp`` is now able to integrate with ``lsp-devtools``, run ``pytest`` with the ``--lsp-devtools`` flag to enable the integration.

--- a/lib/pytest-lsp/pytest_lsp/__init__.py
+++ b/lib/pytest-lsp/pytest_lsp/__init__.py
@@ -5,6 +5,7 @@ from .client import client_capabilities
 from .client import make_test_lsp_client
 from .plugin import ClientServerConfig
 from .plugin import fixture
+from .plugin import pytest_addoption
 from .plugin import pytest_runtest_makereport
 from .protocol import LanguageClientProtocol
 
@@ -17,5 +18,6 @@ __all__ = [
     "client_capabilities",
     "fixture",
     "make_test_lsp_client",
+    "pytest_addoption",
     "pytest_runtest_makereport",
 ]

--- a/lib/pytest-lsp/tests/test_plugin.py
+++ b/lib/pytest-lsp/tests/test_plugin.py
@@ -1,8 +1,69 @@
 import pathlib
 import sys
+from typing import Any
+from typing import Dict
+from typing import List
 
 import pygls.uris as uri
 import pytest
+
+from pytest_lsp.plugin import ClientServerConfig
+
+
+@pytest.mark.parametrize(
+    "config, kwargs, expected",
+    [
+        (ClientServerConfig(server_command=["command"]), {}, ["command"]),
+        (
+            ClientServerConfig(server_command=["command"]),
+            {"devtools": "1234"},
+            [
+                "lsp-devtools",
+                "agent",
+                "--host",
+                "localhost",
+                "--port",
+                "1234",
+                "--",
+                "command",
+            ],
+        ),
+        (
+            ClientServerConfig(server_command=["command"]),
+            {"devtools": "localhost:1234"},
+            [
+                "lsp-devtools",
+                "agent",
+                "--host",
+                "localhost",
+                "--port",
+                "1234",
+                "--",
+                "command",
+            ],
+        ),
+        (
+            ClientServerConfig(server_command=["command"]),
+            {"devtools": "127.0.0.1:1234"},
+            [
+                "lsp-devtools",
+                "agent",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "1234",
+                "--",
+                "command",
+            ],
+        ),
+    ],
+)
+def test_get_server_command(
+    config: ClientServerConfig, kwargs: Dict[str, Any], expected: List[str]
+):
+    """Ensure that we can build the server start command correctly."""
+    actual = config.get_server_command(**kwargs)
+    assert expected == actual
 
 
 def setup_test(pytester: pytest.Pytester, server_name: str, test_code: str):


### PR DESCRIPTION
It's now possible to use `lsp-devtools` commands to inspect servers under test with `pytest-lsp`
Requires the `lsp-devtools` command to be on the user's `PATH`, so it's recommended to install `lsp-devtools` using [pipx](https://pypa.github.io/pipx/)

Closes #97 