### PR TITLE
lsp-devtools: Don't close server on client exit

### DIFF
--- a/lib/lsp-devtools/changes/110.enhancement.rst
+++ b/lib/lsp-devtools/changes/110.enhancement.rst
@@ -1,0 +1,1 @@
+Commands like ``lsp-devtools record`` and ``lsp-devtools inspect`` will no longer exit/stop capturing messages after the first LSP session exits

--- a/lib/lsp-devtools/lsp_devtools/agent/server.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/server.py
@@ -47,8 +47,11 @@ class AgentServer(Server):
             writer.close()
             await writer.wait_closed()
 
-            if self._tcp_server is not None:
-                self._tcp_server.cancel()
+            # Uncomment if we ever need to introduce a mode where the server stops
+            # automatically once a session ends.
+            #
+            # if self._tcp_server is not None:
+            #     self._tcp_server.cancel()
 
         server = await asyncio.start_server(handle_client, host, port)
         async with server:


### PR DESCRIPTION
This allows commands like ``lsp-devtools record`` or ``lsp-devtools inspect`` to capture multiple sessions without exiting