### PR TITLE
Fix casing for `window.work_done_progress`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,19 @@ repos:
   rev: 23.11.0
   hooks:
   - id: black
-    exclude: 'lib/pytest-lsp/pytest_lsp/gen.py'
 
 - repo: https://github.com/PyCQA/flake8
   rev: 6.1.0
   hooks:
   - id: flake8
+    name: flake8 (lsp-devtools)
     args: [--config=lib/lsp-devtools/setup.cfg]
+    files: 'lib/lsp-devtools/lsp_devtools/.*\.py'
+
+  - id: flake8
+    name: flake8 (pytest-lsp)
+    args: [--config=lib/pytest-lsp/setup.cfg]
+    files: 'lib/pytest-lsp/pytest_lsp/.*\.py'
 
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0
@@ -33,7 +39,6 @@ repos:
     name: isort (pytest-lsp)
     args: [--settings-file, lib/pytest-lsp/pyproject.toml]
     files: 'lib/pytest-lsp/pytest_lsp/.*\.py'
-    exclude: 'lib/pytest-lsp/pytest_lsp/gen.py'
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: 'v1.7.0'

--- a/lib/pytest-lsp/changes/119.fix.rst
+++ b/lib/pytest-lsp/changes/119.fix.rst
@@ -1,0 +1,1 @@
+`LspSpecificationWarnings` will no longer be incorrectly emitted when a client does indeed support `window/workDoneProgress/create` requests

--- a/lib/pytest-lsp/pytest_lsp/checks.py
+++ b/lib/pytest-lsp/pytest_lsp/checks.py
@@ -252,7 +252,7 @@ def work_done_progress_create(
 ):
     """Assert that the client has support for ``window/workDoneProgress/create``
     requests."""
-    is_supported = get_capability(capabilities, "window.workDoneProgress", False)
+    is_supported = get_capability(capabilities, "window.work_done_progress", False)
     assert is_supported, "Client does not support 'window/workDoneProgress/create'"
 
 

--- a/lib/pytest-lsp/setup.cfg
+++ b/lib/pytest-lsp/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 88
+ignore = E501

--- a/lib/pytest-lsp/setup.cfg
+++ b/lib/pytest-lsp/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 88
-ignore = E501
+ignore = E203,E501


### PR DESCRIPTION
This stops `pytest-lsp` from incorrectly raising warnings about `window/workDoneProgress/create` support