### PR TITLE
Nix update

### DIFF
--- a/lib/pytest-lsp/.gitignore
+++ b/lib/pytest-lsp/.gitignore
@@ -1,1 +1,2 @@
 .coverage
+result

--- a/lib/pytest-lsp/flake.lock
+++ b/lib/pytest-lsp/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688556768,
-        "narHash": "sha256-mhd6g0iJGjEfOr3+6mZZOclUveeNr64OwxdbNtLc8mY=",
+        "lastModified": 1704161960,
+        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27bd67e55fe09f9d68c77ff151c3e44c4f81f7de",
+        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {

--- a/lib/pytest-lsp/flake.nix
+++ b/lib/pytest-lsp/flake.nix
@@ -14,27 +14,36 @@
       pytest-lsp-overlay = import ./nix/pytest-lsp-overlay.nix;
     in {
 
-    overlays.default = pytest-lsp-overlay;
+      overlays.default = pytest-lsp-overlay;
 
-    devShells = utils.lib.eachDefaultSystemMap (system:
-      let
-        pkgs = import nixpkgs { inherit system; overlays = [ pytest-lsp-overlay ]; };
-      in
-        eachPythonVersion [ "38" "39" "310" "311" ] (pyVersion:
-          with pkgs; mkShell {
-            name = "py${pyVersion}";
+      packages = utils.lib.eachDefaultSystemMap (system:
+        let
+          pkgs = import nixpkgs { inherit system; overlays = [ pytest-lsp-overlay ]; };
+        in
+          eachPythonVersion [ "38" "39" "310" "311"] (pyVersion:
+            pkgs."python${pyVersion}Packages".pytest-lsp
+          )
+      );
 
-            shellHook = ''
-              export PYTHONPATH="./:$PYTHONPATH"
-            '';
+      devShells = utils.lib.eachDefaultSystemMap (system:
+        let
+          pkgs = import nixpkgs { inherit system; overlays = [ pytest-lsp-overlay ]; };
+        in
+          eachPythonVersion [ "38" "39" "310" "311" ] (pyVersion:
+            with pkgs; mkShell {
+              name = "py${pyVersion}";
 
-            packages = with pkgs."python${pyVersion}Packages"; [
-              pygls
-              pytest
-              pytest-asyncio
-            ];
-          }
-      )
-    );
-  };
+              shellHook = ''
+                export PYTHONPATH="./:$PYTHONPATH"
+              '';
+
+              packages = with pkgs."python${pyVersion}Packages"; [
+                pygls
+                pytest
+                pytest-asyncio
+              ];
+            }
+          )
+      );
+    };
 }

--- a/lib/pytest-lsp/nix/pytest-lsp-overlay.nix
+++ b/lib/pytest-lsp/nix/pytest-lsp-overlay.nix
@@ -1,10 +1,17 @@
-final: prev: {
+final: prev:
+
+let
+  # Read the package's version from file
+  lines = prev.lib.splitString "\n" (builtins.readFile ../pytest_lsp/client.py);
+  matches = builtins.map (builtins.match ''__version__ = "(.+)"'') lines;
+  versionStr = prev.lib.concatStrings (prev.lib.flatten (builtins.filter builtins.isList matches));
+in {
   pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [(
     python-final: python-prev: {
 
       pytest-lsp = python-prev.buildPythonPackage {
         pname = "pytest-lsp";
-        version = "0.3.0";
+        version = versionStr;
         format = "pyproject";
 
         src = ./..;

--- a/lib/pytest-lsp/nix/pytest-lsp-overlay.nix
+++ b/lib/pytest-lsp/nix/pytest-lsp-overlay.nix
@@ -2,50 +2,6 @@ final: prev: {
   pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [(
     python-final: python-prev: {
 
-      # TODO: Remove once https://github.com/NixOS/nixpkgs/pull/233870 is merged
-      typeguard = python-prev.typeguard.overridePythonAttrs (oldAttrs: rec {
-        version = "3.0.2";
-        format = "pyproject";
-
-        src = prev.fetchPypi {
-          inherit version;
-          pname = oldAttrs.pname;
-          sha256 = "sha256-/uUpf9so+Onvy4FCte4hngI3VQnNd+qdJwta+CY1jVo=";
-        };
-
-        propagatedBuildInputs = with python-prev; [
-          importlib-metadata
-          typing-extensions
-        ];
-
-      });
-
-      lsprotocol = python-prev.lsprotocol.overridePythonAttrs(oldAttrs: rec {
-        version = "2023.0.0a3";
-
-        src = prev.fetchFromGitHub {
-          rev = version;
-          owner = "microsoft";
-          repo = oldAttrs.pname;
-          sha256 = "sha256-Q4jvUIMMaDX8mvdmRtYKHB2XbMEchygO2NMmMQdNkTc=";
-        };
-      });
-
-      pygls = python-prev.pygls.overridePythonAttrs (_: {
-        format = "pyproject";
-
-        src = prev.fetchFromGitHub {
-          owner = "openlawlibrary";
-          repo = "pygls";
-          rev = "main";
-          hash = "sha256-JpopfqeLNi23TuZ5mkPEShUPScd1fB0IDXSVGvDYFXE=";
-        };
-
-        nativeBuildInputs = with python-prev; [
-          poetry-core
-        ];
-      });
-
       pytest-lsp = python-prev.buildPythonPackage {
         pname = "pytest-lsp";
         version = "0.3.0";

--- a/lib/pytest-lsp/nix/pytest-lsp-overlay.nix
+++ b/lib/pytest-lsp/nix/pytest-lsp-overlay.nix
@@ -5,8 +5,13 @@ final: prev: {
       pytest-lsp = python-prev.buildPythonPackage {
         pname = "pytest-lsp";
         version = "0.3.0";
+        format = "pyproject";
 
         src = ./..;
+
+        nativeBuildInputs = with python-final; [
+          hatchling
+        ];
 
         propagatedBuildInputs = with python-final; [
           pygls
@@ -15,12 +20,10 @@ final: prev: {
         ];
 
         doCheck = true;
-
+        pythonImportsCheck = [ "pytest_lsp" ];
         nativeCheckInputs = with python-prev; [
           pytestCheckHook
         ];
-
-        pythonImportsCheck = [ "pytest_lsp" ];
 
       };
     }


### PR DESCRIPTION
- Remove old package overrides
- Read version number for `pytest-lsp` from file
- Re-align package definition for `pytest-lsp` 