### PR TITLE
Set non-empty default format strings

### DIFF
--- a/docs/lsp-devtools/guide/record-command.rst
+++ b/docs/lsp-devtools/guide/record-command.rst
@@ -29,6 +29,7 @@ Here are some example usages of the ``record`` command that you may find useful.
 
 The following command will save to a JSON file only the client's info and :class:`pygls:lsprotocol.types.ClientCapabilities` sent during the ``initialize`` request - useful for :ref:`adding clients to pytest-lsp <pytest-lsp-supported-clients>`! 😉
 
+
 ::
 
    lsp-devtools record -f '{{"clientInfo": {.params.clientInfo}, "capabilities": {.params.capabilities}}}' --to-file <client_name>_v<version>.json
@@ -291,21 +292,28 @@ Formatting messages
 Formatters
 ^^^^^^^^^^
 
-``lsp-devtools`` knows how to format the following LSP Types
+``lsp-devtools`` provides the following formatters
 
-``Position``
+``json`` (default)
+  Renders objects as "pretty" JSON, equivalent to ``json.dumps(obj, indent=2)``
+
+``json-compact``
+  Renders objects as JSON with no additional formatting, equivalent to ``json.dumps(obj)``
+
+``position``
    ``{"line": 1, "character": 2}`` will be rendered as ``1:2``
 
-``Range``
+``range``
    ``{"start": {"line": 1, "character": 2}, "end": {"line": 3, "character": 4}}`` will be rendered as ``1:2-3:4``
 
-Additionally, any enum type can be used as a formatter in which case a number will be replaced with the corresponding name, for example::
+
+Additionally, any enum type can be used as a formatter, where numbers will be replaced with their corresponding name, for example::
 
   Format String:
   "{.type|MessageType}"
 
-  Value:    Result:
-  1         Error
-  2         Warning
-  3         Info
-  4         Log
+  Value:          Result:
+  {"type": 1}     Error
+  {"type": 2}     Warning
+  {"type": 3}     Info
+  {"type": 4}     Log

--- a/lib/lsp-devtools/changes/130.enhancement.md
+++ b/lib/lsp-devtools/changes/130.enhancement.md
@@ -1,0 +1,1 @@
+Added formatters `json` and `json-compact` that can be used within format strings.

--- a/lib/lsp-devtools/changes/130.fix.md
+++ b/lib/lsp-devtools/changes/130.fix.md
@@ -1,0 +1,1 @@
+The `lsp-devtools record` command will now produce valid JSON when using the `--to-file` option without an explicitly provided format string.

--- a/lib/lsp-devtools/lsp_devtools/record/formatters.py
+++ b/lib/lsp-devtools/lsp_devtools/record/formatters.py
@@ -1,7 +1,9 @@
 import json
 import re
+from functools import partial
 from typing import Any
 from typing import Callable
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -17,11 +19,11 @@ except ImportError:
     cache = lru_cache(None)
 
 
-def format_json(obj: dict) -> str:
+def format_json(obj: dict, *, indent: Union[str, int, None] = 2) -> str:
     if isinstance(obj, str):
         return obj
 
-    return json.dumps(obj, indent=2)
+    return json.dumps(obj, indent=indent)
 
 
 def format_position(position: dict) -> str:
@@ -32,9 +34,11 @@ def format_range(range_: dict) -> str:
     return f"{format_position(range_['start'])}-{format_position(range_['end'])}"
 
 
-FORMATTERS = {
+FORMATTERS: Dict[str, Callable[[Any], str]] = {
     "position": format_position,
     "range": format_range,
+    "json": format_json,
+    "json-compact": partial(format_json, indent=None),
 }
 
 

--- a/lib/lsp-devtools/tests/record/test_formatters.py
+++ b/lib/lsp-devtools/tests/record/test_formatters.py
@@ -19,6 +19,20 @@ from lsp_devtools.record.formatters import FormatString
             "The method 'textDocument/completion' was called",
         ),
         (
+            "{.position|json}",
+            {
+                "position": {"line": 1, "character": 2},
+            },
+            '{\n  "line": 1,\n  "character": 2\n}',
+        ),
+        (
+            "{.position|json-compact}",
+            {
+                "position": {"line": 1, "character": 2},
+            },
+            '{"line": 1, "character": 2}',
+        ),
+        (
             "{.method} {.params.textDocument.uri}:{.params.position}",
             {
                 "method": "textDocument/completion",

--- a/lib/lsp-devtools/tests/record/test_record.py
+++ b/lib/lsp-devtools/tests/record/test_record.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import typing
+
+import pytest
+
+from lsp_devtools.record import cli
+from lsp_devtools.record import setup_file_output
+
+if typing.TYPE_CHECKING:
+    import pathlib
+    from typing import Any
+    from typing import Dict
+    from typing import List
+
+
+@pytest.fixture(scope="module")
+def record():
+    """Return a cli parser for the record command."""
+    parser = argparse.ArgumentParser(description="for testing purposes")
+    commands = parser.add_subparsers()
+    cli(commands)
+
+    return parser
+
+
+@pytest.fixture()
+def logger():
+    """Return the logger instance to use."""
+
+    log = logging.getLogger(__name__)
+    log.setLevel(logging.INFO)
+
+    for handler in log.handlers:
+        log.removeHandler(handler)
+
+    return log
+
+
+@pytest.mark.parametrize(
+    "args, messages, expected",
+    [
+        (
+            [],
+            [dict(jsonrpc="2.0", id=1, method="initialize", params=dict())],
+            '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}\n',
+        ),
+        (
+            ["-f", "{.|json-compact}"],
+            [dict(jsonrpc="2.0", id=1, method="initialize", params=dict())],
+            '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}\n',
+        ),
+        (
+            ["-f", "{.|json}"],
+            [dict(jsonrpc="2.0", id=1, method="initialize", params=dict())],
+            "\n".join(
+                [
+                    "{",
+                    '  "jsonrpc": "2.0",',
+                    '  "id": 1,',
+                    '  "method": "initialize",',
+                    '  "params": {}',
+                    "}",
+                    "",
+                ]
+            ),
+        ),
+        (
+            ["-f", "{.method|json}"],
+            [
+                dict(jsonrpc="2.0", id=1, method="initialize", params=dict()),
+                dict(jsonrpc="2.0", id=1, result=dict()),
+            ],
+            "initialize\n",
+        ),
+        (
+            ["-f", "{.id}"],
+            [
+                dict(jsonrpc="2.0", id=1, method="initialize", params=dict()),
+                dict(jsonrpc="2.0", id=1, result=dict()),
+            ],
+            "1\n1\n",
+        ),
+    ],
+)
+def test_file_output(
+    tmp_path: pathlib.Path,
+    record: argparse.ArgumentParser,
+    logger: logging.Logger,
+    args: List[str],
+    messages: List[Dict[str, Any]],
+    expected: str,
+):
+    """Ensure that we can log to files correctly.
+
+    Parameters
+    ----------
+    tmp_path
+       pytest's ``tmp_path`` fixture
+
+    record
+       The record command's cli parser
+
+    logger
+       The logging instance to use
+
+    messages
+       The messages to record
+
+    expected
+       The expected file output.
+    """
+    log = tmp_path / "log.json"
+    parsed_args = record.parse_args(["record", "--to-file", str(log), *args])
+
+    setup_file_output(parsed_args, logger)
+
+    for message in messages:
+        logger.info("%s", message, extra={"source": "client"})
+
+    assert log.read_text() == expected

--- a/lib/lsp-devtools/tox.ini
+++ b/lib/lsp-devtools/tox.ini
@@ -11,8 +11,6 @@ wheel_build_env = .pkg
 deps =
      coverage[toml]
      pytest
-
-     git+https://github.com/openlawlibrary/pygls
 commands_pre =
     coverage erase
 commands =


### PR DESCRIPTION
By setting default format strings like `{.|json}` or `{.|json-compact}` we ensure that the `lsp-devtools record` command produces valid JSON when using the `--to-file` option.

Closes #130