### PR TITLE
Add support for "value" capabilities

### DIFF
--- a/docs/capabilities/general.rst
+++ b/docs/capabilities/general.rst
@@ -1,0 +1,30 @@
+``general``
+===========
+
+.. default-domain:: capabilities
+
+.. values-table:: general.position_encodings
+   :value-set: PositionEncodingKind
+
+``staleRequestSupport``
+-----------------------
+
+.. bool-table:: general.stale_request_support.cancel
+
+.. values-table:: general.stale_request_support.retry_on_content_modified
+
+``regularExpressions``
+----------------------
+
+.. values-table:: general.regular_expressions.engine
+
+.. values-table:: general.regular_expressions.version
+
+``markdown``
+------------
+
+.. values-table:: general.markdown.parser
+
+.. values-table:: general.markdown.version
+
+.. values-table:: general.markdown.allowed_tags

--- a/docs/capabilities/notebook-document.rst
+++ b/docs/capabilities/notebook-document.rst
@@ -1,0 +1,11 @@
+``notebook``
+============
+
+.. default-domain:: capabilities
+
+``synchronization``
+-------------------
+
+.. bool-table:: notebook_document.synchronization.dynamic_registration
+
+.. bool-table:: notebook_document.synchronization.execution_summary_support

--- a/docs/capabilities/text-document.rst
+++ b/docs/capabilities/text-document.rst
@@ -1,5 +1,5 @@
-Text Document
-=============
+``textDocument``
+================
 
 .. toctree::
    :maxdepth: 1

--- a/docs/capabilities/text-document/call-hierachy.rst
+++ b/docs/capabilities/text-document/call-hierachy.rst
@@ -1,0 +1,8 @@
+``callHierarchy``
+=================
+
+Capabilities relating to the :lsp:`textDocument/prepareCallHierarchy` request.
+
+.. default-domain:: capabilities
+
+.. bool-table:: text_document.call_hierarchy.dynamic_registration

--- a/docs/capabilities/text-document/code-action.rst
+++ b/docs/capabilities/text-document/code-action.rst
@@ -1,29 +1,21 @@
-``textDocument/codeAction``
-===========================
+``codeAction``
+==============
 
 Capabilities relating to the :lsp:`textDocument/codeAction` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.code_action.dynamic_registration
+.. bool-table:: text_document.code_action.dynamic_registration
 
-Honors Change Annotations
--------------------------
+.. values-table:: text_document.code_action.code_action_literal_support.code_action_kind.value_set
+   :value-set: CodeActionKind
 
-.. capabilities:bool-table:: text_document.code_action.honors_change_annotations
+.. bool-table:: text_document.code_action.is_preferred_support
 
-``CodeAction.isPreferred``
---------------------------
+.. bool-table:: text_document.code_action.disabled_support
 
-.. capabilities:bool-table:: text_document.code_action.is_preferred_support
+.. bool-table:: text_document.code_action.data_support
 
-``CodeAction.disabled``
------------------------
+.. values-table:: text_document.code_action.resolve_support.properties
 
-.. capabilities:bool-table:: text_document.code_action.disabled_support
-
-``CodeAction.data``
--------------------
-
-.. capabilities:bool-table:: text_document.code_action.data_support
+.. bool-table:: text_document.code_action.honors_change_annotations

--- a/docs/capabilities/text-document/code-lens.rst
+++ b/docs/capabilities/text-document/code-lens.rst
@@ -1,9 +1,8 @@
-``textDocument/codeLens``
-=========================
+``codeLens``
+============
 
 Capabilities relating to the :lsp:`textDocument/codeLens` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.code_lens.dynamic_registration
+.. bool-table:: text_document.code_lens.dynamic_registration

--- a/docs/capabilities/text-document/completion.rst
+++ b/docs/capabilities/text-document/completion.rst
@@ -1,40 +1,60 @@
-``textDocument/completion``
-===========================
-
-Dynamic Registration
---------------------
+``completion``
+==============
 
 Capabilities relating to the :lsp:`textDocument/completion` request.
 
-.. capabilities:bool-table:: text_document.completion.dynamic_registration
+.. default-domain:: capabilities
+
+.. bool-table:: text_document.completion.dynamic_registration
+
+.. bool-table:: text_document.completion.context_support
+
+.. values-table:: text_document.completion.insert_text_mode
+
+``completionItem``
+------------------
+
+.. bool-table:: text_document.completion.completion_item.snippet_support
+
+.. bool-table:: text_document.completion.completion_item.commit_characters_support
+
+.. values-table:: text_document.completion.completion_item.documentation_format
+   :value-set: MarkupKind
+
+.. bool-table:: text_document.completion.completion_item.deprecated_support
+
+.. bool-table:: text_document.completion.completion_item.preselect_support
+
+.. bool-table:: text_document.completion.completion_item.insert_replace_support
+
+.. bool-table:: text_document.completion.completion_item.label_details_support
+
+``insertTextModeSupport``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. values-table:: text_document.completion.completion_item.insert_text_mode_support.value_set
+   :value-set: InsertTextMode
+
+``resolveSupport``
+^^^^^^^^^^^^^^^^^^
+
+.. values-table:: text_document.completion.completion_item.resolve_support.properties
 
 
-``CompletionItem.commitCharactersSupport``
-------------------------------------------
+``tagSupport``
+^^^^^^^^^^^^^^
 
-.. capabilities:bool-table:: text_document.completion.completion_item.commit_characters_support
+.. values-table:: text_document.completion.completion_item.tag_support.value_set
+   :value-set: CompletionItemTag
 
-``CompletionItem.deprecatedSupport``
-------------------------------------
 
-.. capabilities:bool-table:: text_document.completion.completion_item.deprecated_support
+``completionItemKind``
+----------------------
 
-``CompletionItem.insertReplaceSupport``
----------------------------------------
+.. values-table:: text_document.completion.completion_item_kind.value_set
+   :value-set: CompletionItemKind
 
-.. capabilities:bool-table:: text_document.completion.completion_item.insert_replace_support
+``completionList``
+------------------
 
-``CompletionItem.labelDetailsSupport``
---------------------------------------
-
-.. capabilities:bool-table:: text_document.completion.completion_item.label_details_support
-
-``CompletionItem.preselectSupport``
------------------------------------
-
-.. capabilities:bool-table:: text_document.completion.completion_item.preselect_support
-
-``CompletionItem.snippetSupport``
----------------------------------
-
-.. capabilities:bool-table:: text_document.completion.completion_item.snippet_support
+.. values-table:: text_document.completion.completion_list.item_defaults

--- a/docs/capabilities/text-document/declaration.rst
+++ b/docs/capabilities/text-document/declaration.rst
@@ -1,14 +1,10 @@
-``textDocument/declaration``
-============================
+``declaration``
+===============
 
 Capabilities relating to the :lsp:`textDocument/declaration` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.declaration.dynamic_registration
+.. bool-table:: text_document.declaration.dynamic_registration
 
-Link Support
-------------
-
-.. capabilities:bool-table:: text_document.declaration.link_support
+.. bool-table:: text_document.declaration.link_support

--- a/docs/capabilities/text-document/definition.rst
+++ b/docs/capabilities/text-document/definition.rst
@@ -1,14 +1,10 @@
-``textDocument/definition``
-============================
+``definition``
+==============
 
 Capabilities relating to the :lsp:`textDocument/definition` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.definition.dynamic_registration
+.. bool-table:: text_document.definition.dynamic_registration
 
-Link Support
-------------
-
-.. capabilities:bool-table:: text_document.definition.link_support
+.. bool-table:: text_document.definition.link_support

--- a/docs/capabilities/text-document/diagnostic.rst
+++ b/docs/capabilities/text-document/diagnostic.rst
@@ -1,14 +1,10 @@
-``textDocument/diagnostic``
-===========================
+``diagnostic``
+==============
 
 Capabilities relating to the :lsp:`textDocument/diagnostic` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.diagnostic.dynamic_registration
+.. bool-table:: text_document.diagnostic.dynamic_registration
 
-Related Document Support
-------------------------
-
-.. capabilities:bool-table:: text_document.diagnostic.related_document_support
+.. bool-table:: text_document.diagnostic.related_document_support

--- a/docs/capabilities/text-document/document-color.rst
+++ b/docs/capabilities/text-document/document-color.rst
@@ -1,9 +1,8 @@
-``textDocument/documentColor``
-==============================
+``documentColor``
+=================
 
 Capabilities relating to the :lsp:`textDocument/documentColor` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.color_provider.dynamic_registration
+.. bool-table:: text_document.color_provider.dynamic_registration

--- a/docs/capabilities/text-document/document-highlight.rst
+++ b/docs/capabilities/text-document/document-highlight.rst
@@ -1,9 +1,8 @@
-``textDocument/documentHighlight``
-==================================
+``documentHighlight``
+=====================
 
 Capabilities relating to the :lsp:`textDocument/documentHighlight` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.document_highlight.dynamic_registration
+.. bool-table:: text_document.document_highlight.dynamic_registration

--- a/docs/capabilities/text-document/document-link.rst
+++ b/docs/capabilities/text-document/document-link.rst
@@ -1,14 +1,10 @@
-``textDocument/documentLink``
-==================================
+``documentLink``
+================
 
 Capabilities relating to the :lsp:`textDocument/documentLink` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.document_link.dynamic_registration
+.. bool-table:: text_document.document_link.dynamic_registration
 
-Tooltip Support
----------------
-
-.. capabilities:bool-table:: text_document.document_link.tooltip_support
+.. bool-table:: text_document.document_link.tooltip_support

--- a/docs/capabilities/text-document/document-symbols.rst
+++ b/docs/capabilities/text-document/document-symbols.rst
@@ -1,19 +1,25 @@
-``textDocument/documentSymbols``
-================================
+``documentSymbols``
+===================
 
 Capabilities relating to the :lsp:`textDocument/documentSymbols` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.document_symbol.dynamic_registration
+.. bool-table:: text_document.document_symbol.dynamic_registration
 
-Hierarchical Symbols
---------------------
+.. bool-table:: text_document.document_symbol.hierarchical_document_symbol_support
 
-.. capabilities:bool-table:: text_document.document_symbol.hierarchical_document_symbol_support
+.. bool-table:: text_document.document_symbol.label_support
 
-Label Support
--------------
 
-.. capabilities:bool-table:: text_document.document_symbol.label_support
+``symbolKind``
+--------------
+
+.. values-table:: text_document.document_symbol.symbol_kind.value_set
+   :value-set: SymbolKind
+
+``tagSupport``
+--------------
+
+.. values-table:: text_document.document_symbol.tag_support.value_set
+   :value-set: SymbolTag

--- a/docs/capabilities/text-document/folding-range.rst
+++ b/docs/capabilities/text-document/folding-range.rst
@@ -1,14 +1,24 @@
-``textDocument/foldingRange``
-=============================
+``foldingRange``
+================
 
 Capabilities relating to the :lsp:`textDocument/foldingRange` request.
 
-Dynamic Registration
+.. default-domain:: capabilities
+
+.. bool-table:: text_document.folding_range.dynamic_registration
+
+.. values-table:: text_document.folding_range.range_limit
+
+.. bool-table:: text_document.folding_range.line_folding_only
+
+``foldingRange``
+----------------
+
+.. bool-table:: text_document.folding_range.folding_range.collapsed_text
+
+
+``foldingRangeKind``
 --------------------
 
-.. capabilities:bool-table:: text_document.folding_range.dynamic_registration
-
-Line Folding Only
------------------
-
-.. capabilities:bool-table:: text_document.folding_range.line_folding_only
+.. values-table:: text_document.folding_range.folding_range_kind.value_set
+   :value-set: FoldingRangeKind

--- a/docs/capabilities/text-document/formatting.rst
+++ b/docs/capabilities/text-document/formatting.rst
@@ -1,9 +1,8 @@
-``textDocument/formatting``
-=============================
+``formatting``
+==============
 
 Capabilities relating to the :lsp:`textDocument/formatting` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.formatting.dynamic_registration
+.. bool-table:: text_document.formatting.dynamic_registration

--- a/docs/capabilities/text-document/hover.rst
+++ b/docs/capabilities/text-document/hover.rst
@@ -1,9 +1,11 @@
-``textDocument/hover``
-======================
+``hover``
+=========
 
 Capabilities relating to the :lsp:`textDocument/hover` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.hover.dynamic_registration
+.. bool-table:: text_document.hover.dynamic_registration
+
+.. values-table:: text_document.hover.content_format
+   :value-set: MarkupKind

--- a/docs/capabilities/text-document/implementation.rst
+++ b/docs/capabilities/text-document/implementation.rst
@@ -1,14 +1,10 @@
-``textDocument/implementation``
-===============================
+``implementation``
+==================
 
 Capabilities relating to the :lsp:`textDocument/implementation` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.implementation.dynamic_registration
+.. bool-table:: text_document.implementation.dynamic_registration
 
-Link Support
-------------
-
-.. capabilities:bool-table:: text_document.implementation.link_support
+.. bool-table:: text_document.implementation.link_support

--- a/docs/capabilities/text-document/inlay-hint.rst
+++ b/docs/capabilities/text-document/inlay-hint.rst
@@ -1,9 +1,13 @@
-``textDocument/inlayHint``
-==========================
+``inlayHint``
+=============
 
 Capabilities relating to the :lsp:`textDocument/inlayHint` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.inlay_hint.dynamic_registration
+.. bool-table:: text_document.inlay_hint.dynamic_registration
+
+``resolveSupport``
+------------------
+
+.. values-table:: text_document.inlay_hint.resolve_support.properties

--- a/docs/capabilities/text-document/inline-value.rst
+++ b/docs/capabilities/text-document/inline-value.rst
@@ -1,9 +1,8 @@
-``textDocument/inlineValue``
-============================
+``inlineValue``
+===============
 
 Capabilities relating to the :lsp:`textDocument/inlineValue` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.inline_value.dynamic_registration
+.. bool-table:: text_document.inline_value.dynamic_registration

--- a/docs/capabilities/text-document/linked-editing-range.rst
+++ b/docs/capabilities/text-document/linked-editing-range.rst
@@ -1,9 +1,8 @@
-``textDocument/linkedEditingRange``
-===================================
+``linkedEditingRange``
+======================
 
 Capabilities relating to the :lsp:`textDocument/linkedEditingRange` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.linked_editing_range.dynamic_registration
+.. bool-table:: text_document.linked_editing_range.dynamic_registration

--- a/docs/capabilities/text-document/moniker.rst
+++ b/docs/capabilities/text-document/moniker.rst
@@ -1,9 +1,8 @@
-``textDocument/moniker``
-========================
+``moniker``
+===========
 
 Capabilities relating to the :lsp:`textDocument/moniker` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.moniker.dynamic_registration
+.. bool-table:: text_document.moniker.dynamic_registration

--- a/docs/capabilities/text-document/on-type-formatting.rst
+++ b/docs/capabilities/text-document/on-type-formatting.rst
@@ -1,9 +1,8 @@
-``textDocument/onTypeFormatting``
-=================================
+``onTypeFormatting``
+====================
 
 Capabilities relating to the :lsp:`textDocument/onTypeFormatting` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.on_type_formatting.dynamic_registration
+.. bool-table:: text_document.on_type_formatting.dynamic_registration

--- a/docs/capabilities/text-document/preapare-call-hierachy.rst
+++ b/docs/capabilities/text-document/preapare-call-hierachy.rst
@@ -1,9 +1,0 @@
-``textDocument/prepareCallHierarchy``
-=====================================
-
-Capabilities relating to the :lsp:`textDocument/prepareCallHierarchy` request.
-
-Dynamic Registration
---------------------
-
-.. capabilities:bool-table:: text_document.call_hierarchy.dynamic_registration

--- a/docs/capabilities/text-document/preapare-type-hierachy.rst
+++ b/docs/capabilities/text-document/preapare-type-hierachy.rst
@@ -1,9 +1,0 @@
-``textDocument/prepareTypeHierarchy``
-=====================================
-
-Capabilities relating to the :lsp:`textDocument/prepareTypeHierarchy` request.
-
-Dynamic Registration
---------------------
-
-.. capabilities:bool-table:: text_document.type_hierarchy.dynamic_registration

--- a/docs/capabilities/text-document/publish-diagnostics.rst
+++ b/docs/capabilities/text-document/publish-diagnostics.rst
@@ -1,24 +1,20 @@
-``textDocument/publishDiagnostics``
-===================================
+``publishDiagnostics``
+======================
 
-Capabilities relating to the :lsp:`textDocument/publishDiagnostics` notification.
+Capabilities relating to the :lsp:`textDocument/publishDiagnostics` notification
 
-Related Information
--------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.publish_diagnostics.related_information
+.. bool-table:: text_document.publish_diagnostics.related_information
 
-Version Support
----------------
+.. bool-table:: text_document.publish_diagnostics.version_support
 
-.. capabilities:bool-table:: text_document.publish_diagnostics.version_support
+.. bool-table:: text_document.publish_diagnostics.code_description_support
 
-Code Description
-----------------
+.. bool-table:: text_document.publish_diagnostics.data_support
 
-.. capabilities:bool-table:: text_document.publish_diagnostics.code_description
+``tagSupport``
+--------------
 
-Data Support
-------------
-
-.. capabilities:bool-table:: text_document.publish_diagnostics.data_support
+.. values-table:: text_document.publish_diagnostics.tag_support.value_set
+   :value-set: DiagnosticTag

--- a/docs/capabilities/text-document/range-formatting.rst
+++ b/docs/capabilities/text-document/range-formatting.rst
@@ -1,9 +1,8 @@
-``textDocument/rangeFormatting``
-================================
+``rangeFormatting``
+===================
 
 Capabilities relating to the :lsp:`textDocument/rangeFormatting` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.range_formatting.dynamic_registration
+.. bool-table:: text_document.range_formatting.dynamic_registration

--- a/docs/capabilities/text-document/references.rst
+++ b/docs/capabilities/text-document/references.rst
@@ -1,9 +1,8 @@
-``textDocument/references``
-===============================
+``references``
+==============
 
 Capabilities relating to the :lsp:`textDocument/references` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.references.dynamic_registration
+.. bool-table:: text_document.references.dynamic_registration

--- a/docs/capabilities/text-document/rename.rst
+++ b/docs/capabilities/text-document/rename.rst
@@ -1,19 +1,18 @@
-``textDocument/rename``
-=======================
+``rename``
+==========
 
 Capabilities relating to the :lsp:`textDocument/rename` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.rename.dynamic_registration
+.. bool-table:: text_document.rename.dynamic_registration
 
-Prepare Support
----------------
+.. bool-table:: text_document.rename.prepare_support
 
-.. capabilities:bool-table:: text_document.rename.prepare_support
+.. bool-table:: text_document.rename.honors_change_annotations
 
-Honors Change Annotations
--------------------------
 
-.. capabilities:bool-table:: text_document.rename.honors_change_annotations
+``prepareSupportDefaultBehavior``
+---------------------------------
+
+.. values-table:: text_document.rename.prepare_support_default_behavior

--- a/docs/capabilities/text-document/selection-range.rst
+++ b/docs/capabilities/text-document/selection-range.rst
@@ -1,9 +1,8 @@
-``textDocument/selectionRange``
-===============================
+``selectionRange``
+==================
 
 Capabilities relating to the :lsp:`textDocument/selectionRange` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.selection_range.dynamic_registration
+.. bool-table:: text_document.selection_range.dynamic_registration

--- a/docs/capabilities/text-document/semantic-tokens.rst
+++ b/docs/capabilities/text-document/semantic-tokens.rst
@@ -1,45 +1,28 @@
-``textDocument/semanticTokens``
-===============================
+``semanticTokens``
+==================
 
 Capabilities relating to :lsp:`textDocument/semanticTokens`.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.semantic_tokens.dynamic_registration
+.. bool-table:: text_document.semantic_tokens.dynamic_registration
 
-``textDocument/semanticTokens/range``
--------------------------------------
+.. bool-table:: text_document.semantic_tokens.requests.range
 
-.. capabilities:bool-table:: text_document.semantic_tokens.requests.range
+.. bool-table:: text_document.semantic_tokens.requests.full
 
-``textDocument/semanticTokens/full``
--------------------------------------
+.. bool-table:: text_document.semantic_tokens.requests.full.delta
 
-.. capabilities:bool-table:: text_document.semantic_tokens.requests.full
+.. values-table:: text_document.semantic_tokens.token_types
+   :value-set: SemanticTokenTypes
 
-``textDocument/semanticTokens/full/delta``
-------------------------------------------
+.. values-table:: text_document.semantic_tokens.token_modifiers
+   :value-set: SemanticTokenModifiers
 
-.. capabilities:bool-table:: text_document.semantic_tokens.requests.full.delta
+.. bool-table:: text_document.semantic_tokens.overlapping_token_support
 
+.. bool-table:: text_document.semantic_tokens.multiline_token_support
 
-Overlapping Tokens
-------------------
+.. bool-table:: text_document.semantic_tokens.server_cancel_support
 
-.. capabilities:bool-table:: text_document.semantic_tokens.overlapping_token_support
-
-Multiline Tokens
-----------------
-
-.. capabilities:bool-table:: text_document.semantic_tokens.multiline_token_support
-
-Server Cancel Support
----------------------
-
-.. capabilities:bool-table:: text_document.semantic_tokens.server_cancel_support
-
-Augments Syntax Tokens
-----------------------
-
-.. capabilities:bool-table:: text_document.semantic_tokens.augments_syntax_tokens
+.. bool-table:: text_document.semantic_tokens.augments_syntax_tokens

--- a/docs/capabilities/text-document/signature-help.rst
+++ b/docs/capabilities/text-document/signature-help.rst
@@ -1,24 +1,21 @@
-``textDocument/signatureHelp``
-==============================
+``signatureHelp``
+=================
 
 Capabilities relating to the :lsp:`textDocument/signatureHelp` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.signature_help.dynamic_registration
+.. bool-table:: text_document.signature_help.dynamic_registration
 
-Label Offset Support
---------------------
+.. bool-table:: text_document.signature_help.context_support
 
-.. capabilities:bool-table:: text_document.signature_help.signature_information.parameter_information.label_offset_support
-
-Active Parameter Support
+``signatureInformation``
 ------------------------
 
-.. capabilities:bool-table:: text_document.signature_help.signature_information.active_parameter_support
+.. bool-table:: text_document.signature_help.signature_information.active_parameter_support
 
-Context Support
----------------
 
-.. capabilities:bool-table:: text_document.signature_help.context_support
+``parameterInformation``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. bool-table:: text_document.signature_help.signature_information.parameter_information.label_offset_support

--- a/docs/capabilities/text-document/synchronization.rst
+++ b/docs/capabilities/text-document/synchronization.rst
@@ -1,0 +1,12 @@
+``synchronization``
+===================
+
+.. default-domain:: capabilities
+
+.. bool-table:: text_document.synchronization.dynamic_registration
+
+.. bool-table:: text_document.synchronization.did_save
+
+.. bool-table:: text_document.synchronization.will_save
+
+.. bool-table:: text_document.synchronization.will_save_wait_until

--- a/docs/capabilities/text-document/type-definition.rst
+++ b/docs/capabilities/text-document/type-definition.rst
@@ -1,14 +1,10 @@
-``textDocument/typeDefinition``
-===============================
+``typeDefinition``
+==================
 
 Capabilities relating to the :lsp:`textDocument/typeDefinition` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: text_document.type_definition.dynamic_registration
+.. bool-table:: text_document.type_definition.dynamic_registration
 
-Link Support
-------------
-
-.. capabilities:bool-table:: text_document.type_definition.link_support
+.. bool-table:: text_document.type_definition.link_support

--- a/docs/capabilities/text-document/type-hierachy.rst
+++ b/docs/capabilities/text-document/type-hierachy.rst
@@ -1,0 +1,8 @@
+``typeHierarchy``
+=================
+
+Capabilities relating to the :lsp:`textDocument/prepareTypeHierarchy` request.
+
+.. default-domain:: capabilities
+
+.. bool-table:: text_document.type_hierarchy.dynamic_registration

--- a/docs/capabilities/window.rst
+++ b/docs/capabilities/window.rst
@@ -1,5 +1,5 @@
-Window
-======
+``window``
+==========
 
 .. toctree::
    :maxdepth: 1

--- a/docs/capabilities/window/progress.rst
+++ b/docs/capabilities/window/progress.rst
@@ -1,4 +1,4 @@
-``window/workDoneProgress/create``
-==================================
+``workDoneProgress``
+====================
 
 .. capabilities:bool-table:: window.work_done_progress

--- a/docs/capabilities/window/show-document.rst
+++ b/docs/capabilities/window/show-document.rst
@@ -1,5 +1,5 @@
-``window/showDocument``
-=======================
+``showDocument``
+================
 
 Capabilities relating to the :lsp:`window/showDocument` request.
 

--- a/docs/capabilities/window/show-message.rst
+++ b/docs/capabilities/window/show-message.rst
@@ -1,9 +1,11 @@
-``window/showMessageRequest``
-=============================
+``showMessage``
+===============
 
 Capabilities relating to the :lsp:`window/showMessageRequest` request.
 
-Additional Properties Support
------------------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: window.show_message.message_action_item.additional_properties_support
+``messageActionItem``
+---------------------
+
+.. bool-table:: window.show_message.message_action_item.additional_properties_support

--- a/docs/capabilities/workspace.rst
+++ b/docs/capabilities/workspace.rst
@@ -1,5 +1,5 @@
-Workspace
-=========
+``workspace``
+=============
 
 .. toctree::
    :maxdepth: 1

--- a/docs/capabilities/workspace/apply-edit.rst
+++ b/docs/capabilities/workspace/apply-edit.rst
@@ -1,6 +1,8 @@
-``workspace/applyEdit``
-=======================
+``applyEdit``
+=============
 
 Capabilities relating to the :lsp:`workspace/applyEdit` request.
 
-.. capabilities:bool-table:: workspace.apply_edit
+.. default-domain:: capabilities
+
+.. bool-table:: workspace.apply_edit

--- a/docs/capabilities/workspace/code-lens.rst
+++ b/docs/capabilities/workspace/code-lens.rst
@@ -1,9 +1,6 @@
-``workspace/codeLens/refresh``
-==============================
+``codeLens``
+============
 
 Capabilities relating to the :lsp:`workspace/codeLens/refresh` request.
-
-Refresh Support
----------------
 
 .. capabilities:bool-table:: workspace.code_lens.refresh_support

--- a/docs/capabilities/workspace/configuration.rst
+++ b/docs/capabilities/workspace/configuration.rst
@@ -1,16 +1,8 @@
-``workspace/configuration``
-===========================
+``configuration``
+=================
 
 Capabilities relating to the :lsp:`workspace/configuration` request.
 
-.. capabilities:bool-table:: workspace.configuration
+.. default-domain:: capabilities
 
-``workspace/didChangeConfiguration``
-====================================
-
-Capabilities relating to the :lsp:`workspace/didChangeConfiguration` notification.
-
-Dynamic Registration
---------------------
-
-.. capabilities:bool-table:: workspace.did_change_configuration.dynamic_registration
+.. bool-table:: workspace.configuration

--- a/docs/capabilities/workspace/diagnostics.rst
+++ b/docs/capabilities/workspace/diagnostics.rst
@@ -1,0 +1,6 @@
+``diagnostics``
+===============
+
+Capabilities relating to the :lsp:`workspace/diagnostic/refresh` request.
+
+.. capabilities:bool-table:: workspace.diagnostics.refresh_support

--- a/docs/capabilities/workspace/did-change-configuration.rst
+++ b/docs/capabilities/workspace/did-change-configuration.rst
@@ -1,0 +1,8 @@
+``didChangeConfiguration``
+==========================
+
+Capabilities relating to the :lsp:`workspace/didChangeConfiguration` notification.
+
+.. default-domain:: capabilities
+
+.. bool-table:: workspace.did_change_configuration.dynamic_registration

--- a/docs/capabilities/workspace/did-change-watched-files.rst
+++ b/docs/capabilities/workspace/did-change-watched-files.rst
@@ -1,0 +1,8 @@
+``didChangeWatchedFiles``
+=========================
+
+.. default-domain:: capabilities
+
+.. bool-table:: workspace.did_change_watched_files.dynamic_registration
+
+.. bool-table:: workspace.did_change_watched_files.relative_pattern_support

--- a/docs/capabilities/workspace/execute-command.rst
+++ b/docs/capabilities/workspace/execute-command.rst
@@ -1,5 +1,5 @@
-``workspace/executeCommand``
-============================
+``executeCommand``
+==================
 
 Capabilities relating to the :lsp:`workspace/executeCommand` request.
 

--- a/docs/capabilities/workspace/file-operations.rst
+++ b/docs/capabilities/workspace/file-operations.rst
@@ -1,56 +1,18 @@
-``workspace/willCreateFiles``
-=============================
+``fileOperations``
+==================
 
-Capabilities relating to the :lsp:`workspace/willCreateFiles` request.
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: workspace.file_operations.will_create
+.. bool-table:: workspace.file_operations.dynamic_registration
 
-``workspace/didCreateFiles``
-=============================
+.. bool-table:: workspace.file_operations.will_create
 
-Capabilities relating to the :lsp:`workspace/didCreateFiles` notification.
+.. bool-table:: workspace.file_operations.did_create
 
-.. capabilities:bool-table:: workspace.file_operations.did_create
+.. bool-table:: workspace.file_operations.will_rename
 
-``workspace/willRenameFiles``
-=============================
+.. bool-table:: workspace.file_operations.did_rename
 
-Capabilities relating to the :lsp:`workspace/willRenameFiles` request.
+.. bool-table:: workspace.file_operations.will_delete
 
-.. capabilities:bool-table:: workspace.file_operations.will_rename
-
-``workspace/didRenameFiles``
-=============================
-
-Capabilities relating to the :lsp:`workspace/didRenameFiles` notification.
-
-.. capabilities:bool-table:: workspace.file_operations.did_rename
-
-``workspace/willDeleteFiles``
-=============================
-
-Capabilities relating to the :lsp:`workspace/willDeleteFiles` request.
-
-.. capabilities:bool-table:: workspace.file_operations.will_delete
-
-``workspace/didDeleteFiles``
-=============================
-
-Capabilities relating to the :lsp:`workspace/didDeleteFiles` notification.
-
-.. capabilities:bool-table:: workspace.file_operations.did_delete
-
-``workspace/didChangeWatchedFiles``
-===================================
-
-Capabilities relating to the :lsp:`workspace/didChangeWatchedFiles` notification.
-
-Dynamic Registration
---------------------
-
-.. capabilities:bool-table:: workspace.did_change_watched_files.dynamic_registration
-
-Relative Pattern Support
-------------------------
-
-.. capabilities:bool-table:: workspace.did_change_watched_files.relative_pattern_support
+.. bool-table:: workspace.file_operations.did_delete

--- a/docs/capabilities/workspace/inlay-hint.rst
+++ b/docs/capabilities/workspace/inlay-hint.rst
@@ -1,9 +1,6 @@
-``workspace/inlayHint/refresh``
-===============================
+``inlayHint``
+=============
 
 Capabilities relating to the :lsp:`workspace/inlayHint/refresh` request.
-
-Refresh Support
----------------
 
 .. capabilities:bool-table:: workspace.inlay_hint.refresh_support

--- a/docs/capabilities/workspace/inline-value.rst
+++ b/docs/capabilities/workspace/inline-value.rst
@@ -1,9 +1,6 @@
-``workspace/inlineValue/refresh``
-=================================
+``inlineValue``
+===============
 
 Capabilities relating to the :lsp:`workspace/inlineValue/refresh` request.
-
-Rehresh Support
----------------
 
 .. capabilities:bool-table:: workspace.inline_value.refresh_support

--- a/docs/capabilities/workspace/semantic-tokens.rst
+++ b/docs/capabilities/workspace/semantic-tokens.rst
@@ -1,0 +1,6 @@
+``semanticTokens``
+==================
+
+Capabilities relating to the :lsp:`workspace/semanticTokens/refresh` request.
+
+.. capabilities:bool-table:: workspace.semantic_tokens.refresh_support

--- a/docs/capabilities/workspace/symbol.rst
+++ b/docs/capabilities/workspace/symbol.rst
@@ -1,9 +1,25 @@
-``workspace/symbol``
-====================
+``symbol``
+==========
 
 Capabilities relating to the :lsp:`workspace/symbol` request.
 
-Dynamic Registration
---------------------
+.. default-domain:: capabilities
 
-.. capabilities:bool-table:: workspace.symbol.dynamic_registration
+.. bool-table:: workspace.symbol.dynamic_registration
+
+``symbolKind``
+--------------
+
+.. values-table:: workspace.symbol.symbol_kind.value_set
+   :value-set: SymbolKind
+
+``tagSupport``
+--------------
+
+.. values-table:: workspace.symbol.tag_support.value_set
+   :value-set: SymbolTag
+
+``resolveSupport``
+------------------
+
+.. values-table:: workspace.symbol.resolve_support.properties

--- a/docs/capabilities/workspace/workspace-edit.rst
+++ b/docs/capabilities/workspace/workspace-edit.rst
@@ -1,0 +1,18 @@
+``workspaceEdit``
+=================
+
+.. default-domain:: capabilities
+
+.. bool-table:: workspace.workspace_edit.document_changes
+
+.. values-table:: workspace.workspace_edit.resource_operations
+   :value-set: ResourceOperationKind
+
+.. values-table:: workspace.workspace_edit.failure_handling
+
+.. bool-table:: workspace.workspace_edit.normalizes_line_endings
+
+``changeAnnotationSupport``
+---------------------------
+
+.. bool-table:: workspace.workspace_edit.change_annotation_support.groups_on_label

--- a/docs/capabilities/workspace/workspace-folders.rst
+++ b/docs/capabilities/workspace/workspace-folders.rst
@@ -1,5 +1,5 @@
-``workspace/workspaceFolders``
-==============================
+``workspaceFolders``
+====================
 
 Capabilities relating to the :lsp:`workspace/workspaceFolders` request.
 

--- a/docs/ext/capabilities.py
+++ b/docs/ext/capabilities.py
@@ -1,34 +1,95 @@
+import enum
 import importlib.resources as resources
 import json
+import operator
 import pathlib
 import re
 import typing
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 import attrs
 from docutils import nodes
 from docutils.parsers.rst import directives
+from docutils.statemachine import StringList
 from lsprotocol import types
 from lsprotocol.converters import get_converter
 from packaging.version import parse as parse_version
 from pygls.capabilities import get_capability
+from sphinx import addnodes
 from sphinx.application import Sphinx
+from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain
 from sphinx.pycode import ModuleAnalyzer
 from sphinx.util.docutils import SphinxDirective
 
 
-class BoolTable(SphinxDirective):
+class CapabilityTable(ObjectDescription[str]):
+    """Base directive for generating tables describing support for LSP capabilities."""
+
+    def handle_signature(self, sig: str, signode: addnodes.desc_signature) -> str:
+        """Render the name of the capability."""
+        try:
+            name = to_camel_case(sig)
+            parts = name.split(".")
+            parent_name = ".".join(parts[:-1]) + "."
+
+            domain = self.env.domains[self.domain]
+            documentation, lsp_version = domain.get_capability_documentation(sig)
+
+            # Save the documentation from the spec until we can insert it into the page
+            self.env.temp_data["extra-capability-documentation"] = documentation
+
+            if lsp_version:
+                signode += addnodes.desc_annotation(
+                    lsp_version,
+                    "",
+                    addnodes.desc_sig_literal_string("", f"since v{lsp_version}"),
+                    addnodes.desc_sig_space(),
+                )
+
+            signode["ids"].append(name)
+            signode["python-name"] = sig
+            signode["spec-name"] = name
+            signode += addnodes.desc_addname(parent_name, parent_name)
+            signode += addnodes.desc_name("", parts[-1])
+
+            return name
+        except Exception as exc:
+            breakpoint()
+            return ...
+
+    def _object_hierarchy_parts(
+        self, signode: addnodes.desc_signature
+    ) -> Tuple[str, ...]:
+        """Return the full hierarchy of the capability, used for toctree generation."""
+        name = signode["spec-name"]
+        return tuple(name.split(".")[:-1])
+
+    def _toc_entry_name(self, signode: addnodes.desc_signature) -> str:
+        """Return the name of capability, used for toctree generation."""
+        name = signode["spec-name"]
+        return name.split(".")[-1]
+
+    def render_table(self, contentnode: addnodes.desc_content):
+        """Render the table to insert into the page."""
+        return []
+
+    def transform_content(self, contentnode: addnodes.desc_content):
+        """Insert documentation about the capability."""
+
+        contentnode += self.render_table(contentnode)
+
+        documentation = self.env.temp_data["extra-capability-documentation"]
+        if len(documentation) > 0:
+            self.state.nested_parse(StringList(documentation), 0, contentnode)
+
+
+class BoolCapabilityTable(CapabilityTable):
     """Given a boolean capability, indicate the support across known clients and
     versions"""
-
-    required_arguments = 1
-
-    option_spec = {
-        "caption": directives.unchanged,
-    }
 
     def build_header(self):
         columns = ["Client", "Supported Since"]
@@ -65,7 +126,7 @@ class BoolTable(SphinxDirective):
         rows = []
         clients = self.get_client_support_for(capability)
 
-        for name, version in clients.items():
+        for name, version in sorted(clients.items(), key=operator.itemgetter(0)):
             rows.append(
                 nodes.row(
                     "",
@@ -80,28 +141,133 @@ class BoolTable(SphinxDirective):
 
         return nodes.tbody("", *rows)
 
-    def run(self):
-        domain = self.env.domains["capabilities"]
-
-        capability = self.arguments[0]
-        if len(documentation := domain.get_capability_documentation(capability)) > 0:
-            self.state_machine.insert_input(documentation, "<lsprotocol.types>")
+    def render_table(self, contentnode: addnodes.desc_content):
+        capability = contentnode.parent[0]["python-name"]
 
         header, colspecs = self.build_header()
         body = self.build_body(capability)
 
         table = nodes.table("", nodes.tgroup("", *colspecs, header, body))
 
-        if (caption := self.options.get("caption", None)) is not None:
-            table.insert(0, nodes.title("", caption))
+        return [table]
 
-        paragraph = nodes.paragraph(
+
+class ValueSetCapabilityTable(CapabilityTable):
+    """Given a capability that enumerates a set of values, indicate their support across
+    known clients and versions."""
+
+    option_spec = {
+        "value-set": directives.unchanged,
+        **CapabilityTable.option_spec,
+    }
+
+    def get_known_values(self, capability: str):
+        values = set()
+        domain = self.env.domains["capabilities"]
+
+        for capabilities in domain.clients.values():
+            client_values = get_capability(capabilities, capability, [])
+            if not isinstance(client_values, list):
+                client_values = [client_values]
+
+            for value in client_values:
+                if isinstance(value, enum.Enum):
+                    if isinstance(value, int):
+                        values.add(value.name)
+                    else:
+                        values.add(value.value)
+                else:
+                    values.add(value)
+
+        return sorted(list(values))
+
+    def get_values(self, capability: str):
+        if (value_set := self.options.get("value-set", None)) is None:
+            # No pre-defined list, return a list of all values we see in our client
+            # capabilities
+            return self.get_known_values(capability)
+
+        # TODO: Handle int enums...
+        value_set_type = getattr(types, value_set)
+        if issubclass(value_set_type, int):
+            return sorted([v.name for v in list(value_set_type)])
+        else:
+            return sorted([v.value for v in list(value_set_type)])
+
+    def build_header(self, capability: str):
+        values = self.get_values(capability)
+
+        colspecs = [nodes.colspec("", colwidth="4")] + [
+            nodes.colspec("", colwidth="1") for _ in range(len(values))
+        ]
+        header = nodes.thead(
             "",
-            nodes.Text("Capability: "),
-            nodes.literal("", to_camel_case(capability)),
+            nodes.row(
+                "",
+                nodes.entry("", nodes.Text("Client")),
+                *[nodes.entry("", nodes.literal(value, value)) for value in values],
+            ),
         )
 
-        return [table, paragraph]
+        return header, colspecs
+
+    def get_client_support_for(self, capability: str):
+        domain = self.env.domains["capabilities"]
+        values = self.get_values(capability)
+
+        clients = {}
+        for (name, version), capabilities in domain.clients.items():
+            if name not in clients:
+                clients[name] = {v: None for v in values}
+
+            supported_values = get_capability(capabilities, capability, None)
+            if supported_values is None:
+                continue
+
+            if not isinstance(supported_values, list):
+                supported_values = [supported_values]
+
+            supported_values = set(supported_values)
+            for value in clients[name]:
+                if (existing := clients[name][value]) is None:
+                    clients[name][value] = version
+                else:
+                    clients[name][value] = min(existing, version, key=parse_version)
+
+        client_support = {
+            name: [(v, value[v]) for v in values] for name, value in clients.items()
+        }
+
+        return client_support
+
+    def build_body(self, capability: str):
+        rows = []
+        clients = self.get_client_support_for(capability)
+
+        for name, support in sorted(clients.items(), key=operator.itemgetter(0)):
+            cells = []
+
+            for _, supported_version in support:
+                cells.append(
+                    nodes.entry(
+                        "",
+                        nodes.Text(supported_version or " - "),
+                        classes=["centered"],
+                    ),
+                )
+
+            rows.append(nodes.row("", nodes.entry("", nodes.Text(name)), *cells))
+
+        return nodes.tbody("", *rows)
+
+    def render_table(self, contentnode: addnodes.desc_content):
+        capability = contentnode.parent[0]["python-name"]
+
+        header, colspecs = self.build_header(capability)
+        body = self.build_body(capability)
+
+        table = nodes.table("", nodes.tgroup("", *colspecs, header, body))
+        return table
 
 
 def to_camel_case(snake_text: str) -> str:
@@ -137,27 +303,33 @@ MD_LINK_PATTERN = re.compile(r"\[`?([^\]]+?)`?\]\(([^)]+)\)")
 SINCE_PATTERN = re.compile(r"@since ([\d\.]+)")
 
 
-def process_docstring(lines):
+def process_docstring(lines: List[str]) -> Optional[str]:
     """Fixup LSP docstrings so that they work with reStructuredText syntax
 
-    - Replaces ``@since <version>`` with ``**LSP v<version>**``
+    This modifies the give ``lines`` in-place to:
 
-    - Replaces ``{@link <item>}`` with ``:class:`~lsprotocol.types.<item>` ``
+    - Replace ``{@link <item>}`` with ``:class:`~lsprotocol.types.<item>` ``
 
-    - Replaces markdown hyperlink with reStructuredText equivalent
+    - Replace markdown hyperlink with reStructuredText equivalent
 
-    - Replaces inline markdown code (single "`") with reStructuredText inline code
+    - Replace inline markdown code (single "`") with reStructuredText inline code
       (double "`")
 
-    - Inserts the required newline before a bulleted list
+    - Insert the required newline before a bulleted list
 
-    - Replaces code fences with code blocks
+    - Replace code fences with code blocks
 
-    - Fixes indentation
+    - Fixe indentation
+
+    Returns
+    -------
+    str
+       If ``@since <version>`` was found, the version string will be returned.
     """
 
     line_breaks = []
     code_fences = []
+    lsp_version: Optional[str] = None
 
     for i, line in enumerate(lines):
         if line.startswith("- "):
@@ -172,7 +344,10 @@ def process_docstring(lines):
 
         if (match := SINCE_PATTERN.search(line)) is not None:
             start, end = match.span()
-            lines[i] = "".join([line[:start], f"**LSP v{match.group(1)}**", line[end:]])
+            lsp_version = match.group(1)
+
+            # Remove the @since declaration from the given set of lines.
+            lines[i] = "".join([line[:start], line[end:]])
 
         if (match := LINK_PATTERN.search(line)) is not None:
             start, end = match.span()
@@ -221,12 +396,15 @@ def process_docstring(lines):
     for offset, line in enumerate(line_breaks):
         lines.insert(line + offset, "")
 
+    return lsp_version
+
 
 class CapabilitiesDomain(Domain):
     name = "capabilities"
 
     directives = {
-        "bool-table": BoolTable,
+        "bool-table": BoolCapabilityTable,
+        "values-table": ValueSetCapabilityTable,
     }
 
     def __init__(self, *args, **kwargs):
@@ -236,7 +414,9 @@ class CapabilitiesDomain(Domain):
         self.analyzer = ModuleAnalyzer.for_module("lsprotocol.types")
         self.analyzer.analyze()
 
-    def get_capability_documentation(self, field_name: str) -> List[str]:
+    def get_capability_documentation(
+        self, field_name: str
+    ) -> Tuple[List[str], Optional[str]]:
         """Return the documentation associated with the given capability."""
         type_ = types.ClientCapabilities
         parent = type_.__name__
@@ -252,9 +432,9 @@ class CapabilitiesDomain(Domain):
             parent = type_.__name__
 
         lines = self.analyzer.attr_docs.get((parent, field), [])
-        process_docstring(lines)
+        lsp_version = process_docstring(lines)
 
-        return lines
+        return lines, lsp_version
 
 
 def setup(app: Sphinx):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,10 +7,6 @@ process of developing language servers easier.
 Client Capability Index
 -----------------------
 
-.. warning::
-
-   This is still under construction.
-
 .. important::
 
    This accuracy of this section entirely depends on the captured capabilities data that is `bundled <https://github.com/swyddfa/lsp-devtools/tree/develop/lib/pytest-lsp/pytest_lsp/clients>`__ with pytest-lsp.
@@ -18,21 +14,33 @@ Client Capability Index
    Pull requests for corrections and new data welcome!
 
 .. toctree::
-   :maxdepth: 2
+   :glob:
    :hidden:
    :caption: Client Capabilities
 
-   capabilities/text-document
-   capabilities/workspace
-   capabilities/window
+   capabilities/*
 
 Inspired by `caniuse.com <https://canisue.com>`__ this provides information on which clients support which features of the `LSP Specification <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/>`__.
 
 .. grid:: 2
    :gutter: 2
 
-   .. grid-item-card:: Text Document
+   .. grid-item-card:: General
       :columns: 12
+      :link: /capabilities/general
+      :link-type: doc
+      :text-align: center
+
+      General client capabilities.
+
+   .. grid-item-card:: NotebookDocument
+      :link: /capabilities/notebook-document
+      :link-type: doc
+      :text-align: center
+
+      Capabilities for NotebookDocuments.
+
+   .. grid-item-card:: TextDocument
       :link: /capabilities/text-document
       :link-type: doc
       :text-align: center

--- a/docs/lsp-devtools/guide/record-command.rst
+++ b/docs/lsp-devtools/guide/record-command.rst
@@ -81,7 +81,7 @@ As well as printing to console, the record command supports a number of other ou
 
       lsp-devtools record --to-sqlite example.db
 
-   This database can then be opened in other tools like `datasette <https://datasette.io/>`_, `SQLite Browser <https://sqlitebrowser.org/>`_ or even ``lsp-devtools`` own :doc:`/lsp-devtools/guide/tui-command`.
+   This database can then be opened in other tools like `datasette <https://datasette.io/>`_, `SQLite Browser <https://sqlitebrowser.org/>`_ or even ``lsp-devtools`` own :doc:`/lsp-devtools/guide/inspect-command`.
 
    .. dropdown:: DB Schema
 

--- a/lib/pytest-lsp/142.capability.md
+++ b/lib/pytest-lsp/142.capability.md
@@ -1,0 +1,1 @@
+Add client capabilities for Emacs v29.1

--- a/lib/pytest-lsp/pytest_lsp/clients/emacs_v29.1.json
+++ b/lib/pytest-lsp/pytest_lsp/clients/emacs_v29.1.json
@@ -1,0 +1,175 @@
+{
+  "clientInfo": {
+    "name": "Emacs (eglot)",
+    "version": "29.1"
+  },
+  "capabilities": {
+    "workspace": {
+      "applyEdit": true,
+      "executeCommand": {
+        "dynamicRegistration": false
+      },
+      "workspaceEdit": {
+        "documentChanges": true
+      },
+      "didChangeWatchedFiles": {
+        "dynamicRegistration": true
+      },
+      "symbol": {
+        "dynamicRegistration": false
+      },
+      "configuration": true,
+      "workspaceFolders": true
+    },
+    "textDocument": {
+      "synchronization": {
+        "dynamicRegistration": false,
+        "willSave": true,
+        "willSaveWaitUntil": true,
+        "didSave": true
+      },
+      "completion": {
+        "dynamicRegistration": false,
+        "completionItem": {
+          "snippetSupport": false,
+          "deprecatedSupport": true,
+          "resolveSupport": {
+            "properties": [
+              "documentation",
+              "details",
+              "additionalTextEdits"
+            ]
+          },
+          "tagSupport": {
+            "valueSet": [
+              1
+            ]
+          }
+        },
+        "contextSupport": true
+      },
+      "hover": {
+        "dynamicRegistration": false,
+        "contentFormat": [
+          "markdown",
+          "plaintext"
+        ]
+      },
+      "signatureHelp": {
+        "dynamicRegistration": false,
+        "signatureInformation": {
+          "parameterInformation": {
+            "labelOffsetSupport": true
+          },
+          "activeParameterSupport": true
+        }
+      },
+      "references": {
+        "dynamicRegistration": false
+      },
+      "definition": {
+        "dynamicRegistration": false,
+        "linkSupport": true
+      },
+      "declaration": {
+        "dynamicRegistration": false,
+        "linkSupport": true
+      },
+      "implementation": {
+        "dynamicRegistration": false,
+        "linkSupport": true
+      },
+      "typeDefinition": {
+        "dynamicRegistration": false,
+        "linkSupport": true
+      },
+      "documentSymbol": {
+        "dynamicRegistration": false,
+        "hierarchicalDocumentSymbolSupport": true,
+        "symbolKind": {
+          "valueSet": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26
+          ]
+        }
+      },
+      "documentHighlight": {
+        "dynamicRegistration": false
+      },
+      "codeAction": {
+        "dynamicRegistration": false,
+        "codeActionLiteralSupport": {
+          "codeActionKind": {
+            "valueSet": [
+              "quickfix",
+              "refactor",
+              "refactor.extract",
+              "refactor.inline",
+              "refactor.rewrite",
+              "source",
+              "source.organizeImports"
+            ]
+          }
+        },
+        "isPreferredSupport": true
+      },
+      "formatting": {
+        "dynamicRegistration": false
+      },
+      "rangeFormatting": {
+        "dynamicRegistration": false
+      },
+      "rename": {
+        "dynamicRegistration": false
+      },
+      "inlayHint": {
+        "dynamicRegistration": false
+      },
+      "publishDiagnostics": {
+        "relatedInformation": false,
+        "codeDescriptionSupport": false,
+        "tagSupport": {
+          "valueSet": [
+            1,
+            2
+          ]
+        }
+      }
+    },
+    "window": {
+      "workDoneProgress": true
+    },
+    "general": {
+      "positionEncodings": [
+        "utf-32",
+        "utf-8",
+        "utf-16"
+      ]
+    },
+    "experimental": {}
+  }
+}


### PR DESCRIPTION
This extends the client capability index to include support for capabilities that capture a set of values, e.g. `SymbolKind`.
Closes #96 

This also adds client capabilities for Emacs `v29.1`. 
Closes #104 