### PR TITLE
update link to documentation on PyPI

### DIFF
--- a/lib/lsp-devtools/pyproject.toml
+++ b/lib/lsp-devtools/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.urls]
 "Bug Tracker" = "https://github.com/swyddfa/lsp-devtools/issues"
-"Documentation" = "https://swyddfa.github.io/lsp-devtools/"
+"Documentation" = "https://lsp-devtools.readthedocs.io/en/latest/"
 "Source Code" = "https://github.com/swyddfa/lsp-devtools"
 
 [project.scripts]

--- a/lib/pytest-lsp/pyproject.toml
+++ b/lib/pytest-lsp/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.urls]
 "Bug Tracker" = "https://github.com/swyddfa/lsp-devtools/issues"
-"Documentation" = "https://swyddfa.github.io/lsp-devtools/"
+"Documentation" = "https://lsp-devtools.readthedocs.io/en/latest/"
 "Source Code" = "https://github.com/swyddfa/lsp-devtools"
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
I noticed that the "Documentation" link in the left sidebar is broken. This is true for both, [`pytest-lsp`](https://pypi.org/project/pytest-lsp/), as well as [`lsp-devtools`](https://pypi.org/project/lsp-devtools/).

This PR updates those links by updating the corresponding `pyproject.toml` files. The link is taken from the `README.md` file, which works as expected.