### PR TITLE
Refactor agent implementation

### DIFF
--- a/lib/lsp-devtools/changes/157.fix.md
+++ b/lib/lsp-devtools/changes/157.fix.md
@@ -1,0 +1,1 @@
+All `lsp-devtools` commands should no longer crash when encountering messages containing unicode characters

--- a/lib/lsp-devtools/changes/165.enhancement.rst
+++ b/lib/lsp-devtools/changes/165.enhancement.rst
@@ -1,0 +1,1 @@
+The `lsp-devtools agent` now forwards the server's `stderr` channel

--- a/lib/lsp-devtools/lsp_devtools/agent/protocol.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/protocol.py
@@ -1,47 +1,7 @@
-from typing import Optional
-from typing import Type
+from __future__ import annotations
 
-import attrs
 from pygls.protocol import JsonRPCProtocol
-
-MESSAGE_TEXT_NOTIFICATION = "message/text"
-
-
-@attrs.define
-class MessageText:
-    """The contents of a ``message/text`` notification."""
-
-    text: str
-    """The captured text."""
-
-    timestamp: float
-    """The timestamp of when the message was recorded."""
-
-    session: str
-    """The session id."""
-
-    source: str
-    """The source the text was captured from e.g. client."""
-
-
-@attrs.define
-class MessageTextNotification:
-    """Notify the client of output that was captured by the agent."""
-
-    jsonrpc: str
-    method: str
-    params: MessageText = attrs.field()
 
 
 class AgentProtocol(JsonRPCProtocol):
     """The RPC protocol exposed by the agent."""
-
-    def get_message_type(self, method: str) -> Optional[Type]:
-        if method == MESSAGE_TEXT_NOTIFICATION:
-            return MessageTextNotification
-
-        return super().get_message_type(method)
-
-    def message_text_notification(self, message: MessageText):
-        """Send an ``message/text`` notification to the client."""
-        self.notify(MESSAGE_TEXT_NOTIFICATION, message)

--- a/lib/lsp-devtools/lsp_devtools/client/__init__.py
+++ b/lib/lsp-devtools/lsp_devtools/client/__init__.py
@@ -69,7 +69,9 @@ class LSPClient(App):
 
     def compose(self) -> ComposeResult:
         message_viewer = MessageViewer("")
-        messages_table = MessagesTable(self.db, message_viewer, session=self.session)
+        messages_table = MessagesTable(
+            self.db, message_viewer, session=self.lsp_client.session_id
+        )
 
         yield Header()
         yield Explorer(".")
@@ -145,7 +147,7 @@ def client(args, extra: List[str]):
     db = Database(args.dbpath)
 
     session = str(uuid4())
-    dbhandler = DatabaseLogHandler(db, session=session)
+    dbhandler = DatabaseLogHandler(db)
     dbhandler.setLevel(logging.INFO)
 
     logger.setLevel(logging.INFO)

--- a/lib/lsp-devtools/lsp_devtools/client/lsp.py
+++ b/lib/lsp-devtools/lsp_devtools/client/lsp.py
@@ -1,6 +1,8 @@
 import importlib.metadata
 import json
+from datetime import datetime
 from typing import Optional
+from uuid import uuid4
 
 from lsprotocol import types
 from pygls.lsp.client import BaseLanguageClient
@@ -16,12 +18,17 @@ class RecordingLSProtocol(LanguageServerProtocol):
 
     def __init__(self, server, converter):
         super().__init__(server, converter)
+        self.session_id = ""
 
     def _procedure_handler(self, message):
         logger.info(
             "%s",
             json.dumps(message, default=self._serialize_message),
-            extra={"source": "server"},
+            extra={
+                "Message-Source": "server",
+                "Message-Session": self.session_id,
+                "Message-Timestamp": datetime.now().isoformat(),
+            },
         )
         return super()._procedure_handler(message)
 
@@ -29,7 +36,11 @@ class RecordingLSProtocol(LanguageServerProtocol):
         logger.info(
             "%s",
             json.dumps(data, default=self._serialize_message),
-            extra={"source": "client"},
+            extra={
+                "Message-Source": "client",
+                "Message-Session": self.session_id,
+                "Message-Timestamp": datetime.now().isoformat(),
+            },
         )
         return super()._send_data(data)
 
@@ -40,6 +51,8 @@ class LanguageClient(BaseLanguageClient):
     def __init__(self):
         super().__init__("lsp-devtools", VERSION, protocol_cls=RecordingLSProtocol)
 
+        self.session_id = str(uuid4())
+        self.protocol.session_id = self.session_id  # type: ignore[attr-defined]
         self._server_capabilities: Optional[types.ServerCapabilities] = None
 
     @property

--- a/lib/lsp-devtools/lsp_devtools/record/filters.py
+++ b/lib/lsp-devtools/lsp_devtools/record/filters.py
@@ -47,7 +47,7 @@ class LSPFilter(logging.Filter):
         if not isinstance(message, dict):
             return False
 
-        source = record.__dict__["source"]
+        source = record.__dict__["Message-Source"]
         message_type = get_message_type(message)
         message_method = self._get_message_method(message_type, message)
 

--- a/lib/lsp-devtools/lsp_devtools/record/visualize.py
+++ b/lib/lsp-devtools/lsp_devtools/record/visualize.py
@@ -156,7 +156,7 @@ class SpinnerHandler(logging.Handler):
         self.progress.start()
 
         method = message.get("method", None)
-        source = record.__dict__["source"]
+        source = record.__dict__["Message-Source"]
         args = {}
 
         if method:

--- a/lib/lsp-devtools/tests/record/test_filters.py
+++ b/lib/lsp-devtools/tests/record/test_filters.py
@@ -26,7 +26,7 @@ def test_filter_message_source(filter_source: str, message_source: str, expected
     message = dict(id="1", method="initialize", params={})
 
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", message, None)
-    record.__dict__["source"] = message_source
+    record.__dict__["Message-Source"] = message_source
 
     assert lsp.filter(record) is expected
 
@@ -96,7 +96,7 @@ def test_filter_included_message_types(message: dict, setup: Tuple[List[str], bo
 
     message_types, expected = setup
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", message, None)
-    record.__dict__["source"] = "client"
+    record.__dict__["Message-Source"] = "client"
 
     lsp = LSPFilter(include_message_types=message_types)
     lsp._response_method_map["1"] = ""
@@ -169,7 +169,7 @@ def test_filter_excluded_message_types(message: dict, setup: Tuple[List[str], bo
 
     message_types, expected = setup
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", message, None)
-    record.__dict__["source"] = "client"
+    record.__dict__["Message-Source"] = "client"
 
     lsp = LSPFilter(exclude_message_types=message_types)
     lsp._response_method_map["1"] = ""
@@ -207,7 +207,7 @@ def test_filter_included_method(message: dict, setup: Tuple[List[str], bool]):
 
     methods, expected = setup
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", message, None)
-    record.__dict__["source"] = "client"
+    record.__dict__["Message-Source"] = "client"
 
     lsp = LSPFilter(include_methods=methods)
     assert lsp.filter(record) is expected
@@ -257,12 +257,12 @@ def test_filter_included_method_response_message(
 
     request = dict(id="1", method=method, params={})
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", request, None)
-    record.__dict__["source"] = "client"
+    record.__dict__["Message-Source"] = "client"
 
     lsp.filter(record)
 
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", response, None)
-    record.__dict__["source"] = "server"
+    record.__dict__["Message-Source"] = "server"
 
     assert lsp.filter(record) is expected
 
@@ -298,7 +298,7 @@ def test_filter_excluded_method(message: dict, setup: Tuple[List[str], bool]):
 
     methods, expected = setup
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", message, None)
-    record.__dict__["source"] = "client"
+    record.__dict__["Message-Source"] = "client"
 
     lsp = LSPFilter(exclude_methods=methods)
     assert lsp.filter(record) is expected
@@ -348,12 +348,12 @@ def test_filter_excluded_method_response_message(
 
     request = dict(id="1", method=method, params={})
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", request, None)
-    record.__dict__["source"] = "client"
+    record.__dict__["Message-Source"] = "client"
 
     lsp.filter(record)
 
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", response, None)
-    record.__dict__["source"] = "server"
+    record.__dict__["Message-Source"] = "server"
 
     assert lsp.filter(record) is expected
 
@@ -365,7 +365,7 @@ def test_filter_skip_unformattable_message():
 
     request = dict(id="1", method="textDocument/completion", params={})
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", request, None)
-    record.__dict__["source"] = "client"
+    record.__dict__["Message-Source"] = "client"
 
     lsp.filter(record)
     assert lsp.filter(record) is False
@@ -382,7 +382,7 @@ def test_filter_format_message():
         params=dict(textDocument=dict(uri="file:///path/to/file.txt")),
     )
     record = logging.LogRecord("example", logging.INFO, "", 0, "%s", request, None)
-    record.__dict__["source"] = "client"
+    record.__dict__["Message-Source"] = "client"
 
     assert lsp.filter(record) is True
     assert record.msg == "file:///path/to/file.txt"

--- a/lib/lsp-devtools/tests/record/test_record.py
+++ b/lib/lsp-devtools/tests/record/test_record.py
@@ -118,6 +118,6 @@ def test_file_output(
     setup_file_output(parsed_args, logger)
 
     for message in messages:
-        logger.info("%s", message, extra={"source": "client"})
+        logger.info("%s", message, extra={"Message-Source": "client"})
 
     assert log.read_text() == expected

--- a/lib/lsp-devtools/tests/test_agent.py
+++ b/lib/lsp-devtools/tests/test_agent.py
@@ -24,6 +24,11 @@ def format_message(obj):
     return message.encode()
 
 
+def echo_handler(d: bytes):
+    sys.stdout.buffer.write(d)
+    sys.stdout.flush()
+
+
 @pytest.mark.asyncio
 async def test_agent_exits():
     """Ensure that when the client closes down the lsp session and the server process
@@ -44,6 +49,7 @@ async def test_agent_exits():
         server,
         os.fdopen(stdin_read, mode="rb"),
         os.fdopen(stdout_write, mode="wb"),
+        echo_handler,
     )
 
     os.write(


### PR DESCRIPTION
Rather than try to embed a JSON-RPC message inside another JSON-RPC
message (i.e. the `MessageText` notification) this commit changes the
agent to forward the message onto the inspector program (mostly)
unmodified.

The most important detail is that we leave the message encoded as
bytes, this way we don't introduce any errors caused by Python
counting the length of unicode characters differently, depending on if
they are a string or a sequence of bytes. Closes #157 

```python
>>> len('∊')
1
>>> len('∊'.encode())
3
```

As for the metadata fields that were included in the `MessageText`,
these are now passed as additional headers prepended to the captured
message