### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/pytest-lsp-pr.yml
+++ b/.github/workflows/pytest-lsp-pr.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/docs/pytest-lsp/howto/migrate-to-v1.rst
+++ b/docs/pytest-lsp/howto/migrate-to-v1.rst
@@ -18,7 +18,7 @@ This release removes support for pytest ``v7``, if you have not done so already 
 ``pytest-asyncio``
 ------------------
 
-The minimum required version for ``pytest-asyncio`` is now ``0.24``, see `this guide <https://pytest-asyncio.readthedocs.io/en/latest/how-to-guides/migrate_from_0_23.html>`__ for details on upgrading
+The minimum required version for ``pytest-asyncio`` is now ``v1.0``, see `this guide <https://pytest-asyncio.readthedocs.io/en/stable/how-to-guides/migrate_from_0_23.html>`__ and `the changelog <https://pytest-asyncio.readthedocs.io/en/stable/reference/changelog.html#>`__ for details on upgrading
 
 ``pygls``
 ---------

--- a/docs/pytest-lsp/howto/migrate-to-v1.rst
+++ b/docs/pytest-lsp/howto/migrate-to-v1.rst
@@ -7,7 +7,7 @@ This guide summarises the changes and provides references on where to get more d
 Python Support
 --------------
 
-This release removes support for Python 3.8 and adds support for Python 3.13.
+This release removes support for Python 3.8 and adds support for Python 3.13 and Python 3.14.
 
 ``pytest``
 ----------

--- a/lib/pytest-lsp/changes/201.misc.md
+++ b/lib/pytest-lsp/changes/201.misc.md
@@ -1,3 +1,5 @@
 Updated minimum version of ``pytest-asyncio`` to ``v1``
 
 Updated ``pygls`` to ``v2.0a4``
+
+Add support for Python 3.14

--- a/lib/pytest-lsp/changes/201.misc.md
+++ b/lib/pytest-lsp/changes/201.misc.md
@@ -1,1 +1,3 @@
 Updated minimum version of ``pytest-asyncio`` to ``v1``
+
+Updated ``pygls`` to ``v2.0a4``

--- a/lib/pytest-lsp/changes/201.misc.md
+++ b/lib/pytest-lsp/changes/201.misc.md
@@ -1,0 +1,1 @@
+Updated minimum version of ``pytest-asyncio`` to ``v1``

--- a/lib/pytest-lsp/pyproject.toml
+++ b/lib/pytest-lsp/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "packaging",
-    "pygls>=2.0.0a3",
+    "pygls>=2.0.0a4",
     "pytest>=8.0",
     "pytest-asyncio>=1.0",
 ]

--- a/lib/pytest-lsp/pyproject.toml
+++ b/lib/pytest-lsp/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "packaging",

--- a/lib/pytest-lsp/pyproject.toml
+++ b/lib/pytest-lsp/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
 dependencies = [
     "packaging",
     "pygls>=2.0.0a3",
-    "pytest",
-    "pytest-asyncio>=0.24",
+    "pytest>=8.0",
+    "pytest-asyncio>=1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
- Bump minimum `pytest-asyncio` version to `v1`
- Update `pygls` to `v2.0a4`
- Start testing on Python 3.14