### PR TITLE
Update agent

### DIFF
--- a/.github/workflows/lsp-devtools-pr.yml
+++ b/.github/workflows/lsp-devtools-pr.yml
@@ -14,9 +14,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.13"
         cache: pip
         cache-dependency-path: lib/lsp-devtools/pyproject.toml
 
@@ -41,14 +41,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         allow-prereleases: true
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/lsp-devtools-release.yml
+++ b/.github/workflows/lsp-devtools-release.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
-        python-version: "3.10"
+        python-version: "3.13"
 
     - run: |
         python --version

--- a/lib/lsp-devtools/Makefile
+++ b/lib/lsp-devtools/Makefile
@@ -1,0 +1,9 @@
+.PHONY: clean-env
+clean-env: | $(HATCH)
+	for venv in $$($(HATCH) env show -i --json | jq -r 'keys | join(" ")') ; do $(HATCH) env remove "$${venv}" ; done
+
+.PHONY: test
+test: | $(HATCH)
+	$(HATCH) test
+
+include ../../.devcontainer/tools.mk

--- a/lib/lsp-devtools/changes/125.feature.md
+++ b/lib/lsp-devtools/changes/125.feature.md
@@ -1,0 +1,1 @@
+Add Windows support

--- a/lib/lsp-devtools/changes/203.misc.md
+++ b/lib/lsp-devtools/changes/203.misc.md
@@ -1,0 +1,4 @@
+Update pygls to v2
+
+Add support for Python 3.13 & 3.14.
+Drop support for Python 3.9

--- a/lib/lsp-devtools/lsp_devtools/agent/__init__.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import logging
 import subprocess
 import sys
 
@@ -36,6 +37,15 @@ async def main(args, extra: list[str]):
     if extra is None:
         print("Missing server start command", file=sys.stderr)
         return 1
+
+    logger = logging.getLogger("lsp_devtools")
+    logger.setLevel(logging.DEBUG)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("[%(name)s]: %(message)s"))
+    handler.setLevel(logging.DEBUG)
+
+    logger.addHandler(handler)
 
     command, *arguments = extra
     server = await asyncio.create_subprocess_exec(
@@ -89,7 +99,7 @@ majority of the lsp-devtools suite of tools.
        │              │     │                      │    │              │
        └──────────────┘     └──────────────────────┘    └──────────────┘
                                        │
-                                       │ tcp/websocket
+                                       │ tcp
                                        │
                                 ┌──────────────┐
                                 │              │

--- a/lib/lsp-devtools/lsp_devtools/agent/__init__.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/__init__.py
@@ -6,7 +6,11 @@ import logging
 import subprocess
 import sys
 
+from lsp_devtools.cli.utils import get_log_level
+
 from .agent import Agent
+from .agent import MessageHeader
+from .agent import MessageSource
 from .agent import RPCMessage
 from .agent import logger
 from .agent import parse_rpc_message
@@ -33,21 +37,37 @@ async def forward_stderr(server: asyncio.subprocess.Process):
         sys.stderr.buffer.write(line)
 
 
-async def main(args, extra: list[str]):
-    if extra is None:
-        print("Missing server start command", file=sys.stderr)
-        return 1
+class AgentClientHandler(logging.Handler):
+    """Forwards log messages through the client - server connection."""
 
+    def __init__(self, client: AgentClient, level: int = 0) -> None:
+        super().__init__(level)
+        self.client = client
+
+    def emit(self, record: logging.LogRecord) -> None:
+        msg = (self.format(record) + "\n").encode()
+
+        source = MessageSource.Agent
+        length = len(msg)
+        data = b"".join([MessageHeader.pack(source, length), msg])
+
+        self.client.forward_message(data)
+
+
+async def main(args, cmd: list[str]):
+    client = AgentClient()
+
+    log_level = get_log_level(args.verbose)
     logger = logging.getLogger("lsp_devtools")
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(log_level)
 
-    handler = logging.StreamHandler()
+    handler = AgentClientHandler(client)
     handler.setFormatter(logging.Formatter("[%(name)s]: %(message)s"))
-    handler.setLevel(logging.DEBUG)
+    handler.setLevel(log_level)
 
     logger.addHandler(handler)
 
-    command, *arguments = extra
+    command, *arguments = cmd
     server = await asyncio.create_subprocess_exec(
         command,
         *arguments,
@@ -55,7 +75,7 @@ async def main(args, extra: list[str]):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    client = AgentClient()
+
     agent = Agent(server, sys.stdin.buffer, sys.stdout.buffer, client.forward_message)
 
     await asyncio.gather(
@@ -65,7 +85,11 @@ async def main(args, extra: list[str]):
     )
 
 
-def run_agent(args, extra: list[str]):
+def run_agent(args, extra: list[str] | None):
+    if extra is None:
+        print("Missing server start command", file=sys.stderr)
+        return 1
+
     try:
         asyncio.run(main(args, extra))
     except asyncio.CancelledError:

--- a/lib/lsp-devtools/lsp_devtools/agent/agent.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/agent.py
@@ -1,32 +1,53 @@
 from __future__ import annotations
 
 import asyncio
+import enum
 import inspect
 import json
 import logging
-import re
+import struct
 import sys
 import typing
 from datetime import datetime
 from datetime import timezone
-from functools import partial
 from uuid import uuid4
 
 import attrs
 
+from .io_ import AsyncStreamWriter
+from .io_ import StdinAsyncReader
+from .io_ import StdoutAsyncWriter
+
 if typing.TYPE_CHECKING:
     from collections.abc import Coroutine
+    from concurrent.futures import ThreadPoolExecutor
     from typing import Any
     from typing import BinaryIO
     from typing import Callable
     from typing import Union
 
-    from pygls.io_ import AsyncReader
+    from .io_ import AsyncReader
+    from .io_ import AsyncWriter
 
-    MessageHandler = Callable[[bytes], Union[None, Coroutine[Any, Any, None]]]
+    DataHandler = Callable[[bytes], Union[None, Coroutine[Any, Any, None]]]
+
 
 UTC = timezone.utc
 logger = logging.getLogger("lsp_devtools.agent")
+MessageHeader = struct.Struct("!BI")
+
+
+class MessageSource(enum.IntEnum):
+    """Indicates if a message came from the client or the server."""
+
+    Agent = enum.auto()
+    """Messages coming from the agent itself"""
+
+    Client = enum.auto()
+    """Messages coming from the language client"""
+
+    Server = enum.auto()
+    """Messages coming from the langiage server"""
 
 
 @attrs.define
@@ -73,126 +94,10 @@ def parse_rpc_message(data: bytes) -> RPCMessage:
     if body is None:
         raise ValueError("Missing message body")
 
-    return RPCMessage(headers, body)
-
-
-async def aio_readline(reader: AsyncReader, message_handler: MessageHandler):
-    CONTENT_LENGTH_PATTERN = re.compile(rb"^Content-Length: (\d+)\r\n$")
-
-    # Initialize message buffer
-    message = []
-    content_length = 0
-
-    while True:
-        # Read a header line
-        header = await reader.readline()
-        if not header:
-            break
-        message.append(header)
-
-        # Extract content length if possible
-        if not content_length:
-            match = CONTENT_LENGTH_PATTERN.fullmatch(header)
-            if match:
-                content_length = int(match.group(1))
-
-        # Check if all headers have been read (as indicated by an empty line \r\n)
-        if content_length and not header.strip():
-            # Read body
-            body = await reader.readexactly(content_length)
-            if not body:
-                break
-            message.append(body)
-
-            # Pass message to protocol, optionally async
-            result = message_handler(b"".join(message))
-            if inspect.isawaitable(result):
-                await result
-
-            # Reset the buffer
-            message = []
-            content_length = 0
-
-
-async def get_streams(
-    stdin, stdout
-) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
-    """Convert blocking stdin/stdout streams into async streams."""
-    loop = asyncio.get_running_loop()
-
-    reader = asyncio.StreamReader()
-    read_protocol = asyncio.StreamReaderProtocol(reader)
-    await loop.connect_read_pipe(lambda: read_protocol, stdin)
-
-    write_transport, write_protocol = await loop.connect_write_pipe(
-        asyncio.streams.FlowControlMixin, stdout
-    )
-    writer = asyncio.StreamWriter(write_transport, write_protocol, reader, loop)
-    return reader, writer
-
-
-class Agent:
-    """The Agent sits between a language server and its client, listening to messages
-    enabling them to be recorded."""
-
-    def __init__(
-        self,
-        server: asyncio.subprocess.Process,
-        stdin: BinaryIO,
-        stdout: BinaryIO,
-        handler: MessageHandler,
-    ):
-        self.stdin = stdin
-        self.stdout = stdout
-        self.server = server
-        self.handler = handler
-        self.session_id = str(uuid4())
-
-        self._tasks: set[asyncio.Task] = set()
-        self.reader: asyncio.StreamReader | None = None
-        self.writer: asyncio.StreamWriter | None = None
-
-    async def start(self):
-        # Get async versions of stdin/stdout
-        self.reader, self.writer = await get_streams(self.stdin, self.stdout)
-
-        # Keep mypy happy
-        if self.server.stdin is None or self.server.stdout is None:
-            raise RuntimeError("Unable to find server I/O streams")
-
-        # Connect stdin to the subprocess' stdin
-        client_to_server = asyncio.create_task(
-            aio_readline(
-                self.reader,
-                partial(self.forward_message, "client", self.server.stdin),
-            ),
-        )
-        self._tasks.add(client_to_server)
-
-        # Connect the subprocess' stdout to stdout
-        server_to_client = asyncio.create_task(
-            aio_readline(
-                self.server.stdout,
-                partial(self.forward_message, "server", self.writer),
-            ),
-        )
-        self._tasks.add(server_to_client)
-
-        # Run both connections concurrently.
-        await asyncio.gather(
-            client_to_server,
-            server_to_client,
-            self._watch_server_process(),
-        )
-
-    async def forward_message(
-        self, source: str, dest: asyncio.StreamWriter, message: bytes
-    ):
-        """Forward the given message to the destination channel"""
-
+    # TODO: Reuse me
+    if False:
         # Forward the message as-is to the client/server
         dest.write(message)
-        await dest.drain()
 
         # Include some additional metadata before passing it onto the devtool.
         # TODO: How do we make sure we choose the same encoding as `message`?
@@ -208,6 +113,86 @@ class Agent:
             task = asyncio.create_task(res)
             self._tasks.add(task)
             task.add_done_callback(self._tasks.discard)
+
+    return RPCMessage(headers, body)
+
+
+class Agent:
+    """The Agent sits between a language server and its client, listening to messages
+    enabling them to be recorded."""
+
+    def __init__(
+        self,
+        server: asyncio.subprocess.Process,
+        stdin: BinaryIO,
+        stdout: BinaryIO,
+        handler: DataHandler,
+        executor: ThreadPoolExecutor | None = None,
+    ):
+        self.server = server
+        self.handler = handler
+        self.session_id = str(uuid4())
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+        self.reader: AsyncReader = StdinAsyncReader(stdin, executor)
+        self.writer: AsyncWriter = StdoutAsyncWriter(stdout, executor)
+
+    async def start(self):
+        if (server_stdin := self.server.stdin) is None:
+            raise RuntimeError("Missing stdin for server process")
+
+        if (server_stdout := self.server.stdout) is None:
+            raise RuntimeError("Missing stdout for server process")
+
+        # Connect stdin to the subprocess' stdin
+        client_to_server = asyncio.create_task(
+            self.connect_streams(
+                self.reader,
+                AsyncStreamWriter(server_stdin),
+                MessageSource.Client,
+            ),
+        )
+        self._tasks.add(client_to_server)
+
+        # Connect the subprocess' stdout to stdout
+        server_to_client = asyncio.create_task(
+            self.connect_streams(
+                server_stdout,
+                self.writer,
+                MessageSource.Server,
+            ),
+        )
+        self._tasks.add(server_to_client)
+
+        # Run both connections concurrently.
+        await asyncio.gather(
+            client_to_server,
+            server_to_client,
+            self._watch_server_process(),
+        )
+
+    async def connect_streams(
+        self, source: AsyncReader, dest: AsyncWriter, origin: MessageSource
+    ):
+        """Forward bytes from the source to the destination, while simultaneously
+        passing them to the handler function"""
+
+        logger.debug('%r: loop start', origin)
+        while (data := await source.read(1024)) != b"":
+            # Send the data onto the server/client as-is
+            logger.debug("%r: read: %r bytes", origin, len(data))
+            await dest.write(data)
+
+            # Forward the captured data onto the handler
+            header = MessageHeader.pack(origin.value, len(data))
+            payload = b"".join([header, data])
+
+            if inspect.isawaitable(res := self.handler(payload)):
+                task = asyncio.create_task(res)
+                self._tasks.add(task)
+                task.add_done_callback(self._tasks.discard)
+
+        logger.debug("%r: loop broken", origin)
 
     async def _watch_server_process(self):
         """Once the server process exits, ensure that the agent is also shutdown."""

--- a/lib/lsp-devtools/lsp_devtools/agent/agent.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/agent.py
@@ -19,17 +19,16 @@ from .io_ import StdinAsyncReader
 from .io_ import StdoutAsyncWriter
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Coroutine
     from concurrent.futures import ThreadPoolExecutor
     from typing import Any
     from typing import BinaryIO
-    from typing import Callable
-    from typing import Union
 
     from .io_ import AsyncReader
     from .io_ import AsyncWriter
 
-    DataHandler = Callable[[bytes], Union[None, Coroutine[Any, Any, None]]]
+    DataHandler = Callable[[bytes], None | Coroutine[Any, Any, None]]
 
 
 UTC = timezone.utc
@@ -177,7 +176,7 @@ class Agent:
         """Forward bytes from the source to the destination, while simultaneously
         passing them to the handler function"""
 
-        logger.debug('%r: loop start', origin)
+        logger.debug("%r: loop start", origin)
         while (data := await source.read(1024)) != b"":
             # Send the data onto the server/client as-is
             logger.debug("%r: read: %r bytes", origin, len(data))

--- a/lib/lsp-devtools/lsp_devtools/agent/client.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/client.py
@@ -2,40 +2,30 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import typing
 
 import stamina
-from pygls.client import JsonRPCClient
-from pygls.protocol import default_converter
-
-from lsp_devtools.agent.protocol import AgentProtocol
 
 if typing.TYPE_CHECKING:
     from typing import Any
 
+logger = logging.getLogger(__name__)
 
-class AgentClient(JsonRPCClient):
+
+class AgentClient:
     """Client for connecting to an AgentServer instance."""
 
-    protocol: AgentProtocol
-
     def __init__(self):
-        super().__init__(
-            protocol_cls=AgentProtocol, converter_factory=default_converter
-        )
         self.connected = False
         self._buffer: list[bytes] = []
         self._tasks: set[asyncio.Task[Any]] = set()
 
-    def _report_server_error(self, error, source):
-        # Bail on error
-        # TODO: Report the actual error somehow
-        self._stop_event.set()
-
-    def feature(self, feature_name: str, options: Any | None = None):
-        return self.protocol.fm.feature(feature_name, options)
+        self.reader: asyncio.StreamReader | None = None
+        self.writer: asyncio.StreamWriter | None = None
 
     async def start_tcp(self, host: str, port: int):
+        """Create a TCP connection to an ``AgentServer`` instance"""
         # The user might not have started the server app immediately and since the
         # agent will live as long as the wrapper language server we may as well
         # try indefinitely.
@@ -48,25 +38,28 @@ class AgentClient(JsonRPCClient):
         )
         async for attempt in retries:
             with attempt:
-                await super().start_tcp(host, port)
+                logger.debug("connecting...")
+                self.reader, self.writer = await asyncio.open_connection(host, port)
                 self.connected = True
+                logger.debug("connected.")
 
     def forward_message(self, message: bytes):
         """Forward the given message to the server instance."""
 
-        if not self.connected or self.protocol.writer is None:
+        if not self.connected or self.writer is None:
             self._buffer.append(message)
             return
 
         # Send any buffered messages
         while len(self._buffer) > 0:
-            res = self.protocol.writer.write(self._buffer.pop(0))
+            res = self.writer.write(self._buffer.pop(0))
             if inspect.isawaitable(res):
                 task = asyncio.ensure_future(res)
                 task.add_done_callback(self._tasks.discard)
                 self._tasks.add(task)
 
-        res = self.protocol.writer.write(message)
+        logger.debug("sending message: %r", message)
+        res = self.writer.write(message)
         if inspect.isawaitable(res):
             task = asyncio.ensure_future(res)
             task.add_done_callback(self._tasks.discard)

--- a/lib/lsp-devtools/lsp_devtools/agent/io_.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/io_.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import typing
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Awaitable
+    from concurrent.futures import ThreadPoolExecutor
+    from typing import BinaryIO
+    from typing import Protocol
+
+    class AsyncReader(Protocol):
+        """An asynchronous reader."""
+
+        def read(self, n: int = -1) -> Awaitable[bytes]: ...
+
+        def readexactly(self, n: int) -> Awaitable[bytes]: ...
+
+    class AsyncWriter(Protocol):
+        """An asynchronous writer."""
+
+        def close(self) -> Awaitable[None]: ...
+
+        def write(self, data: bytes) -> Awaitable[None]: ...
+
+
+logger = logging.getLogger(__name__)
+
+
+class StdinAsyncReader:
+    """Read from stdin asynchronously."""
+
+    def __init__(self, stdin: BinaryIO, executor: ThreadPoolExecutor | None = None):
+        self._stdin = stdin
+        self._executor = executor
+        self._lock = threading.Lock()
+        self._buffer = bytearray()
+        self._bytes_available = threading.Event()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._future: asyncio.Future[None] | None = None
+
+    @property
+    def loop(self):
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
+
+        return self._loop
+
+    def _start_read_loop(self):
+        """If required, start background task of reading from stdin."""
+        if self._future is None:
+            self._future = self.loop.run_in_executor(self._executor, self._read_loop)
+
+        return self._future
+
+    def _read_loop(self, n: int = -1):
+        # Yes, I'm sure it's terribly inefficient to read one byte at a time.
+        # However, I have no idea how to otherwise make sure that we don't hang waiting
+        # for more bytes than are currently available.
+        # logger.debug("stdin: loop start")
+        while (b := self._stdin.read(1)) != b"":
+            with self._lock:
+                self._buffer += b
+                self._bytes_available.set()
+                # logger.debug("buffer: %r", len(self._buffer))
+        # logger.debug("stdin: loop end")
+
+    async def read(self, n: int = -1) -> bytes:
+        # If the future is done, then the stream must be closed.
+        if (fut:= self._start_read_loop()).done():
+            return b""
+
+        await self.loop.run_in_executor(self._executor, self._bytes_available.wait)
+        await self.loop.run_in_executor(self._executor, self._lock.acquire)
+
+        try:
+            length = min(n, len(self._buffer))
+            if length == len(self._buffer):
+                self._bytes_available.clear()
+
+            data, self._buffer = self._buffer[:length], self._buffer[length:]
+            logger.debug("chunk: %r, buffer: %r", len(data), len(self._buffer))
+
+            return bytes(data)
+        finally:
+            self._lock.release()
+
+    async def readexactly(self, n: int) -> bytes:
+        self._start_read_loop()
+
+        data = b""
+        remainder = n
+        while len(data) < n:
+            chunk = await self.read(remainder)
+            remainder -= len(chunk)
+            data += chunk
+            logger.debug("r: %r, data: %r", remainder, len(data))
+
+        return data
+
+
+class StdoutAsyncWriter:
+    """Write to stdout asynchronously."""
+
+    def __init__(self, stdout: BinaryIO, executor: ThreadPoolExecutor | None = None):
+        self.stdout = stdout
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self.executor = executor
+
+    @property
+    def loop(self):
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
+
+        return self._loop
+
+    def close(self) -> Awaitable[None]:
+        return self.loop.run_in_executor(self.executor, self.stdout.close)
+
+    def _write(self, data: bytes):
+        self.stdout.write(data)
+        self.stdout.flush()
+
+    def write(self, data: bytes) -> Awaitable[None]:
+        return self.loop.run_in_executor(self.executor, self._write, data)
+
+
+class AsyncStreamWriter:
+    """Thin wrapper around an ``asyncio.StreamWriter`` to align it to the
+    ``AsyncWriter`` protocol."""
+
+    def __init__(self, writer: asyncio.StreamWriter):
+        self.writer = writer
+
+    def close(self) -> Awaitable[None]:
+        self.writer.close()
+        return asyncio.sleep(0)
+
+    def write(self, data: bytes) -> Awaitable[None]:
+        self.writer.write(data)
+        return self.writer.drain()
+
+
+async def get_stdio_streams(
+    stdin: BinaryIO, stdout: BinaryIO
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Convert blocking stdin/stdout streams into async streams.
+
+    .. important::
+
+       This method does NOT work on Windows
+    """
+    loop = asyncio.get_running_loop()
+
+    reader = asyncio.StreamReader()
+    read_protocol = asyncio.StreamReaderProtocol(reader)
+    await loop.connect_read_pipe(lambda: read_protocol, stdin)
+
+    write_transport, write_protocol = await loop.connect_write_pipe(
+        asyncio.streams.FlowControlMixin, stdout
+    )
+    writer = asyncio.StreamWriter(write_transport, write_protocol, reader, loop)
+    return reader, writer

--- a/lib/lsp-devtools/lsp_devtools/agent/io_.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/io_.py
@@ -69,7 +69,7 @@ class StdinAsyncReader:
 
     async def read(self, n: int = -1) -> bytes:
         # If the future is done, then the stream must be closed.
-        if (fut:= self._start_read_loop()).done():
+        if (fut := self._start_read_loop()).done():
             return b""
 
         await self.loop.run_in_executor(self._executor, self._bytes_available.wait)

--- a/lib/lsp-devtools/lsp_devtools/agent/protocol.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/protocol.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-from pygls.protocol import JsonRPCProtocol
-
-
-class AgentProtocol(JsonRPCProtocol):
-    """The RPC protocol exposed by the agent."""

--- a/lib/lsp-devtools/lsp_devtools/agent/server.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/server.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import typing
 
-from lsp_devtools.agent.agent import Header
+from lsp_devtools.agent.agent import MessageHeader
 from lsp_devtools.database import Database
 
 if typing.TYPE_CHECKING:
@@ -22,14 +22,9 @@ async def raw_parser(reader: asyncio.StreamReader, handler):
 
     while True:
         try:
-            logger.debug("Reading %r header bytes...", Header.size)
-            bs = await reader.readexactly(Header.size)
-            logger.debug("got: %r", bs)
-            source, length = Header.unpack(bs)
-
-            logger.debug("Reading %r payload bytes...", length)
+            bs = await reader.readexactly(MessageHeader.size)
+            source, length = MessageHeader.unpack(bs)
             data = await reader.readexactly(length)
-            logger.debug("got: %r", data)
         except asyncio.IncompleteReadError:
             break
 
@@ -38,7 +33,6 @@ async def raw_parser(reader: asyncio.StreamReader, handler):
             continue
 
         try:
-            logger.debug("calling handler")
             handler(data, source)
         except Exception:
             logger.exception("Unable to handle message")

--- a/lib/lsp-devtools/lsp_devtools/agent/server.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/server.py
@@ -9,8 +9,8 @@ from lsp_devtools.database import Database
 
 if typing.TYPE_CHECKING:
     from collections.abc import Awaitable
+    from collections.abc import Callable
     from typing import Any
-    from typing import Callable
 
     MessageParser = Callable[[asyncio.StreamReader, MessageHandler], Awaitable[Any]]
 

--- a/lib/lsp-devtools/lsp_devtools/agent/server.py
+++ b/lib/lsp-devtools/lsp_devtools/agent/server.py
@@ -1,82 +1,87 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import traceback
 import typing
 
-from pygls.protocol import default_converter
-from pygls.server import JsonRPCServer
-
-from lsp_devtools.agent.agent import aio_readline
-from lsp_devtools.agent.protocol import AgentProtocol
+from lsp_devtools.agent.agent import Header
 from lsp_devtools.database import Database
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Awaitable
     from typing import Any
+    from typing import Callable
 
-    from lsp_devtools.agent.agent import MessageHandler
+    MessageParser = Callable[[asyncio.StreamReader, MessageHandler], Awaitable[Any]]
+
+logger = logging.getLogger(__name__)
 
 
-class AgentServer(JsonRPCServer):
-    """A pygls server that accepts connections from agents allowing them to send their
-    collected messages."""
+async def raw_parser(reader: asyncio.StreamReader, handler):
+    """The simplest parser, it only passes on the bytes it receives over the wire."""
 
-    lsp: AgentProtocol
+    while True:
+        try:
+            logger.debug("Reading %r header bytes...", Header.size)
+            bs = await reader.readexactly(Header.size)
+            logger.debug("got: %r", bs)
+            source, length = Header.unpack(bs)
+
+            logger.debug("Reading %r payload bytes...", length)
+            data = await reader.readexactly(length)
+            logger.debug("got: %r", data)
+        except asyncio.IncompleteReadError:
+            break
+
+        except Exception:
+            logger.exception("Unable to parse message")
+            continue
+
+        try:
+            logger.debug("calling handler")
+            handler(data, source)
+        except Exception:
+            logger.exception("Unable to handle message")
+
+
+class AgentServer:
+    """A server that accepts connections from agents allowing them to send their
+    collected messages.
+
+    """
 
     def __init__(
         self,
-        *args,
         logger: logging.Logger | None = None,
+        parser: MessageParser | None = None,
         handler: MessageHandler | None = None,
-        **kwargs,
     ):
-        if "protocol_cls" not in kwargs:
-            kwargs["protocol_cls"] = AgentProtocol
-
-        if "converter_factory" not in kwargs:
-            kwargs["converter_factory"] = default_converter
-
-        super().__init__(*args, **kwargs)
-
         self.logger = logger or logging.getLogger(__name__)
-        self.handler = handler or self._default_handler
+        self.parser = parser or raw_parser
+        self.handler = handler
         self.db: Database | None = None
 
         self._client_buffer: list[str] = []
         self._server_buffer: list[str] = []
         self._tcp_server: asyncio.Task | None = None
 
-    def _default_handler(self, data: bytes):
-        message = self.protocol.structure_message(json.loads(data))
-        self.protocol.handle_message(message)
-
-    def _report_server_error(self, error: Exception, source):
-        """Report internal server errors."""
-        tb = "".join(
-            traceback.format_exception(type(error), error, error.__traceback__)
-        )
-        self.logger.error("%s: %s", type(error).__name__, error)
-        self.logger.debug("%s", tb)
-
-    def feature(self, feature_name: str, options: Any | None = None):
-        return self.lsp.fm.feature(feature_name, options)
-
     async def start_tcp(self, host: str, port: int) -> None:  # type: ignore[override]
+        """Start a TCP server to listen for connections."""
+
         async def handle_client(
             reader: asyncio.StreamReader, writer: asyncio.StreamWriter
         ):
-            self.protocol.set_writer(writer)
-
+            """Handle connections from ``AgentClient`` instances"""
+            logger.debug("Connected to client.")
             try:
-                await aio_readline(reader, self.handler)
+                await self.parser(reader, self.handler)
             except asyncio.CancelledError:
                 pass
             finally:
                 writer.close()
                 await writer.wait_closed()
 
+            logger.debug("Connection closed.")
             # Uncomment if we ever need to introduce a mode where the server stops
             # automatically once a session ends.
             #

--- a/lib/lsp-devtools/lsp_devtools/cli/__init__.py
+++ b/lib/lsp-devtools/lsp_devtools/cli/__init__.py
@@ -40,6 +40,13 @@ def main():
         prog="lsp-devtools", description="Developer tooling for language servers"
     )
     cli.add_argument("--version", action="version", version=f"%(prog)s v{__version__}")
+    cli.add_argument(
+        "-v",
+        "--verbose",
+        default=0,
+        action="count",
+        help="increase the verbosity of the logging output",
+    )
     commands = cli.add_subparsers(title="commands")
 
     for mod in BUILTIN_COMMANDS:

--- a/lib/lsp-devtools/lsp_devtools/cli/utils.py
+++ b/lib/lsp-devtools/lsp_devtools/cli/utils.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import logging
+
+LOG_LEVELS = [logging.WARNING, logging.INFO, logging.DEBUG]
+
+
+def get_log_level(verbosity: int) -> int:
+    """Get the logging level corresponding to the given verbosity"""
+    return LOG_LEVELS[min(max(0, verbosity), len(LOG_LEVELS) - 1)]

--- a/lib/lsp-devtools/lsp_devtools/client/lsp.py
+++ b/lib/lsp-devtools/lsp_devtools/client/lsp.py
@@ -2,7 +2,6 @@ import importlib.metadata
 import json
 from datetime import datetime
 from datetime import timezone
-from typing import Optional
 from uuid import uuid4
 
 from lsprotocol import types
@@ -55,7 +54,7 @@ class LanguageClient(BaseLanguageClient):
 
         self.session_id = str(uuid4())
         self.protocol.session_id = self.session_id  # type: ignore[attr-defined]
-        self._server_capabilities: Optional[types.ServerCapabilities] = None
+        self._server_capabilities: types.ServerCapabilities | None = None
 
     @property
     def server_capabilities(self) -> types.ServerCapabilities:

--- a/lib/lsp-devtools/lsp_devtools/database.py
+++ b/lib/lsp-devtools/lsp_devtools/database.py
@@ -5,7 +5,6 @@ import pathlib
 from contextlib import asynccontextmanager
 from importlib import resources
 from typing import Any
-from typing import Optional
 
 import aiosqlite
 from textual.app import App
@@ -20,10 +19,10 @@ class Database:
     class Update(Message):
         """Sent when there are updates to the database"""
 
-    def __init__(self, dbpath: Optional[pathlib.Path] = None):
+    def __init__(self, dbpath: pathlib.Path | None = None):
         self.dbpath = dbpath or ":memory:"
-        self.db: Optional[aiosqlite.Connection] = None
-        self.app: Optional[App] = None
+        self.db: aiosqlite.Connection | None = None
+        self.app: App | None = None
         self._handlers: dict[str, set] = {}
 
     async def close(self):
@@ -84,7 +83,7 @@ class Database:
         self,
         *,
         session: str = "",
-        max_row: Optional[int] = None,
+        max_row: int | None = None,
     ):
         """Get messages from the database
 

--- a/lib/lsp-devtools/lsp_devtools/record/__init__.py
+++ b/lib/lsp-devtools/lsp_devtools/record/__init__.py
@@ -202,6 +202,26 @@ def start_recording(args, extra: list[str]):
             exporter(str(destination), **kwargs)
 
 
+def demo(args, extra: list[str]):
+    logger = logging.getLogger("lsp_devtools")
+
+    def handler(data: bytes, source):
+        print(f"{source}: {data.decode('utf8')!r}")
+
+    server = AgentServer(logger=logger, handler=handler)
+
+    try:
+        host = args.host
+        port = args.port
+
+        print(f"Waiting for connection on {host}:{port}...", end="\r", flush=True)
+        asyncio.run(server.start_tcp(host, port))
+    except asyncio.CancelledError:
+        pass
+    except KeyboardInterrupt:
+        server.stop()
+
+
 def setup_filter_args(cmd: argparse.ArgumentParser):
     """Add arguments that can be used to filter messages."""
 
@@ -338,4 +358,4 @@ default) and push messages to it and have them be recorded.
         ),
     )
 
-    cmd.set_defaults(run=start_recording)
+    cmd.set_defaults(run=demo)

--- a/lib/lsp-devtools/lsp_devtools/record/formatters.py
+++ b/lib/lsp-devtools/lsp_devtools/record/formatters.py
@@ -9,8 +9,8 @@ from functools import partial
 import lsprotocol.types
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Any
-    from typing import Callable
 
 
 def format_json(obj: dict, *, indent: str | int | None = 2) -> str:

--- a/lib/lsp-devtools/pyproject.toml
+++ b/lib/lsp-devtools/pyproject.toml
@@ -7,7 +7,7 @@ name = "lsp-devtools"
 dynamic = ["version"]
 description = "Developer tooling for language servers"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "Alex Carney", email = "alcarneyme@gmail.com" }]
 classifiers = [
@@ -16,10 +16,11 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "aiosqlite",
@@ -47,7 +48,7 @@ sort = "Cover"
 
 [tool.pyright]
 include = ["lsp_devtools"]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 
 [tool.towncrier]
 filename = "CHANGES.md"

--- a/lib/lsp-devtools/pyproject.toml
+++ b/lib/lsp-devtools/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
   "aiosqlite",
   "platformdirs",
-  "pygls>=2.0a2",
+  "pygls>=2.0a6",
   "stamina",
   "textual>=0.41.0",
 ]

--- a/lib/lsp-devtools/tests/test_agent.py
+++ b/lib/lsp-devtools/tests/test_agent.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import asyncio
 import io
 import json
-import os
 import pathlib
 import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 

--- a/lib/lsp-devtools/tests/test_agent.py
+++ b/lib/lsp-devtools/tests/test_agent.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import asyncio
+import io
 import json
 import os
 import pathlib
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -34,9 +38,6 @@ async def test_agent_exits():
     """Ensure that when the client closes down the lsp session and the server process
     exits, the agent does also."""
 
-    (stdin_read, stdin_write) = os.pipe()
-    (stdout_read, stdout_write) = os.pipe()
-
     server = await asyncio.create_subprocess_exec(
         sys.executable,
         str(SERVER_DIR / "simple.py"),
@@ -45,28 +46,19 @@ async def test_agent_exits():
         stderr=subprocess.PIPE,
     )
 
-    agent = Agent(
-        server,
-        os.fdopen(stdin_read, mode="rb"),
-        os.fdopen(stdout_write, mode="wb"),
-        echo_handler,
-    )
-
-    os.write(
-        stdin_write,
+    messages = [
         format_message(
             dict(jsonrpc="2.0", id=1, method="initialize", params=dict(capabilities={}))
         ),
-    )
-
-    os.write(
-        stdin_write,
         format_message(dict(jsonrpc="2.0", id=2, method="shutdown", params=None)),
-    )
-
-    os.write(
-        stdin_write,
         format_message(dict(jsonrpc="2.0", method="exit", params=None)),
+    ]
+
+    agent = Agent(
+        server,
+        io.BytesIO(b"".join(messages)),
+        io.BytesIO(),
+        echo_handler,
     )
 
     try:

--- a/lib/lsp-devtools/uv.lock
+++ b/lib/lsp-devtools/uv.lock
@@ -1,0 +1,304 @@
+version = 1
+revision = 2
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/00/2432bb2d445b39b5407f0a90e01b9a271475eea7caf913d7a86bcb956385/cattrs-25.3.0.tar.gz", hash = "sha256:1ac88d9e5eda10436c4517e390a4142d88638fe682c436c93db7ce4a277b884a", size = 509321, upload-time = "2025-10-07T12:26:08.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl", hash = "sha256:9896e84e0a5bf723bc7b4b68f4481785367ce07a8a02e7e9ee6eb2819bc306ff", size = 70738, upload-time = "2025-10-07T12:26:06.603Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
+]
+
+[[package]]
+name = "lsp-devtools"
+source = { editable = "." }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygls" },
+    { name = "stamina" },
+    { name = "textual" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiosqlite" },
+    { name = "platformdirs" },
+    { name = "pygls", specifier = ">=2.0a6" },
+    { name = "stamina" },
+    { name = "textual", specifier = ">=0.41.0" },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py", marker = "python_full_version < '3.10'" },
+]
+plugins = [
+    { name = "mdit-py-plugins", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py", marker = "python_full_version >= '3.10'" },
+]
+plugins = [
+    { name = "mdit-py-plugins", version = "0.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542, upload-time = "2024-09-09T20:27:49.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636", size = 55316, upload-time = "2024-09-09T20:27:48.397Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
+]
+
+[[package]]
+name = "pygls"
+version = "2.0.0a6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/42/270542357f5f52e0d7f4951d48b5a39efac6039810b5f9fb3ac9284e5cb8/pygls-2.0.0a6.tar.gz", hash = "sha256:1a94e0252e4bab607690e7dadbe949e1132a1e878325f5ad60c4936506188e49", size = 55930, upload-time = "2025-07-18T18:21:30.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/3b/8c83173e2afd7cb9b75201188c911b39f0b4dce09a3d0224dfc7f225290e/pygls-2.0.0a6-py3-none-any.whl", hash = "sha256:0a4a5f479a1554f8b493cfc4be5061344ae724f3959c51aedbf8c92174293233", size = 69574, upload-time = "2025-07-18T18:21:29.197Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "stamina"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tenacity" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/c4/d242d76ffc88aa1fd14214d3143b542857b32276db4a20f8d99669054a5e/stamina-25.1.0.tar.gz", hash = "sha256:ad674809796ae40512b3b6296cfade826efd63863ff2ca2f59f806342e91e94a", size = 561127, upload-time = "2025-03-12T09:37:08.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/ba/d03f7ee711391af1d5f4dd7c44f8abdd06bce247028af2441ba8f6ff329b/stamina-25.1.0-py3-none-any.whl", hash = "sha256:c08291da540e6f4243c20f7ee98f0ed0ac9101d639803c481a029b56d7e9b45d", size = 17323, upload-time = "2025-03-12T09:37:06.886Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "textual"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["linkify", "plugins"], marker = "python_full_version < '3.10'" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["linkify", "plugins"], marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/51/51a0863339c4c3fa204f43044e52dfd688a7ee2ba2c987e021acc9583a42/textual-6.3.0.tar.gz", hash = "sha256:a89c557fa740611551dcf4f93643f33853eca488183ef5882200dde8e94315e8", size = 1573232, upload-time = "2025-10-11T11:17:01.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/2a/bca677b0b05ee77b4105f73db0d8ef231a9f1db154d69388abd5c73f9dcc/textual-6.3.0-py3-none-any.whl", hash = "sha256:ec908b4b008662e7670af4a3e7c773847066b0950b1c50126c72fa939b514c97", size = 711457, upload-time = "2025-10-11T11:16:59.754Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
+]


### PR DESCRIPTION
This PR begins the much needed overhaul of `lsp-devtools`, starting with re-writing the agent so that it (hopefully!), can finally work on Windows.

This also changes the format of the data sent from the agent to the server application. Instead of trying to parse messages in the agent, the agent simply packages up the bytes with a small header saying who the bytes are from and how many there are and sends them on as-is. This should make it possible to bring back the raw-output mode of the `lsp-devtools` record command.

Closes #125 