### PR TITLE
lsp-devtools: don't use a thread

### DIFF
--- a/lib/lsp-devtools/changes/229.fix.md
+++ b/lib/lsp-devtools/changes/229.fix.md
@@ -1,0 +1,1 @@
+Fix issue where `lsp-devtools inspect` would not exit cleanly

--- a/lib/lsp-devtools/lsp_devtools/cli/inspector.py
+++ b/lib/lsp-devtools/lsp_devtools/cli/inspector.py
@@ -68,7 +68,7 @@ class LSPInspector(App[None]):
         table.focus()
 
         if self.server is not None:
-            self.run_worker(self.server.start_tcp(), name="lsp-connection", thread=True)
+            self.run_worker(self.server.start_tcp(), name="lsp-connection")
 
     async def action_quit(self):
         if self.server is not None:


### PR DESCRIPTION
The [textual docs](https://textual.textualize.io/guide/workers/#thread-workers) suggest that as long as you use async you don't need a separate thread. Since the agent communication is done over asyncio, removing the background appears to fix #229