### PR TITLE
pytest-lsp: handle type annotations that are not classes

### DIFF
--- a/lib/pytest-lsp/changes/237.fix.md
+++ b/lib/pytest-lsp/changes/237.fix.md
@@ -1,0 +1,1 @@
+`pytest-lsp` no longer throws a `TypeError` when you type annotate the `pytest_lsp.fixture` function.

--- a/lib/pytest-lsp/pytest_lsp/plugin.py
+++ b/lib/pytest-lsp/pytest_lsp/plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import inspect
 import logging
 import textwrap
@@ -192,10 +193,13 @@ def get_fixture_arguments(
         required_parameters.remove("request")
 
     # Inject the language client
-    for name, cls in typing.get_type_hints(fn).items():
-        if issubclass(cls, JsonRPCClient):
-            kwargs[name] = client
-            required_parameters.remove(name)
+    for name, annotation in typing.get_type_hints(fn).items():
+        # Not every annotation is a class...
+        # see: https://github.com/swyddfa/lsp-devtools/issues/237
+        with contextlib.suppress(TypeError):
+            if issubclass(annotation, JsonRPCClient):
+                kwargs[name] = client
+                required_parameters.remove(name)
 
     # Assume all remaining parameters are pytest fixtures
     for name in required_parameters:

--- a/lib/pytest-lsp/tests/examples/getting-started/t_server.py
+++ b/lib/pytest-lsp/tests/examples/getting-started/t_server.py
@@ -1,4 +1,5 @@
 import sys
+from collections.abc import AsyncGenerator
 
 import pytest
 from lsprotocol.types import (
@@ -17,7 +18,7 @@ from pytest_lsp import ClientServerConfig, LanguageClient
 @pytest_lsp.fixture(
     config=ClientServerConfig(server_command=[sys.executable, "server.py"]),
 )
-async def client(lsp_client: LanguageClient):
+async def client(lsp_client: LanguageClient) -> AsyncGenerator[None]:
     # Setup
     params = InitializeParams(capabilities=ClientCapabilities())
     await lsp_client.initialize_session(params)


### PR DESCRIPTION
Closes #237 