### PR TITLE
Preserve selected message in inspector on updates

### DIFF
--- a/lib/lsp-devtools/changes/247.fix.md
+++ b/lib/lsp-devtools/changes/247.fix.md
@@ -1,0 +1,1 @@
+Preserve the currently selected message in `lsp-devtools inspect` (and the client inspector) when new traffic arrives, instead of always jumping to the latest row. Auto-follow still happens when the cursor is already on the last message.

--- a/lib/lsp-devtools/lsp_devtools/cli/client/__init__.py
+++ b/lib/lsp-devtools/lsp_devtools/cli/client/__init__.py
@@ -12,7 +12,6 @@ from textual import events
 from textual import on
 from textual.app import App
 from textual.containers import Vertical
-from textual.message import Message
 from textual.widgets import Button
 from textual.widgets import Footer
 
@@ -153,7 +152,9 @@ class LSPClient(App[None]):
     @on(LiveSqlHandler.MessageReceived)
     def on_message_received(self, event: LiveSqlHandler.MessageReceived):
         browser = self.query_one(MessageBrowser)
-        browser.reload(follow=True)
+        # Only jump to the latest message when the user is already following the
+        # tail; otherwise preserve their selected row. See #247.
+        browser.reload(follow=browser.is_following_tail())
 
     def on_button_pressed(self, event: Button.Pressed):
         if event.button.id == "open-settings-btn":
@@ -203,7 +204,7 @@ class LSPClient(App[None]):
 
         await client.start_io(*server_config.command)
 
-        result = await client.initialize_async(
+        await client.initialize_async(
             types.InitializeParams(
                 capabilities=types.ClientCapabilities(),
                 process_id=os.getpid(),

--- a/lib/lsp-devtools/lsp_devtools/cli/inspector.py
+++ b/lib/lsp-devtools/lsp_devtools/cli/inspector.py
@@ -58,7 +58,9 @@ class LSPInspector(App[None]):
     @on(LiveSqlHandler.MessageReceived)
     def on_message_received(self, event: LiveSqlHandler.MessageReceived):
         browser = self.query_one(MessageBrowser)
-        browser.reload(follow=True)
+        # Only jump to the latest message when the user is already following the
+        # tail; otherwise preserve their selected row. See #247.
+        browser.reload(follow=browser.is_following_tail())
 
     async def on_ready(self, event: Ready):
         browser = self.query_one(MessageBrowser)

--- a/lib/lsp-devtools/lsp_devtools/inspector/message_browser.py
+++ b/lib/lsp-devtools/lsp_devtools/inspector/message_browser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 from datetime import datetime
+from datetime import timezone
 
 from textual.containers import Container
 from textual.containers import Horizontal
@@ -141,16 +142,32 @@ class MessageBrowser(Container):
         self.clear()
         self._last_rowid = -1
 
+    def is_following_tail(self) -> bool:
+        """Return ``True`` if the cursor is on (or past) the latest message.
+
+        Used to decide whether newly arrived messages should steal focus. When the
+        user has selected an older row, their selection is preserved.
+        """
+        table = self.query_one(DataTable)
+        if table.row_count == 0:
+            return True
+        return table.cursor_row >= table.row_count - 1
+
     def reload(self, follow: bool = False):
         """Reload messages.
 
         Parameters
         ----------
         follow
-           If ``True``, move the cursor so that the most recent message is selected
+           If ``True``, move the cursor so that the most recent message is selected.
+           If ``False``, keep the currently selected row (if it still exists).
 
         """
         table = self.query_one(DataTable)
+
+        selected_key: RowKey | None = None
+        if not follow and table.row_count > 0:
+            selected_key = table.coordinate_to_cell_key(table.cursor_coordinate).row_key
 
         for rowid, message in self.app.db.find_messages(after=self._last_rowid):
             # TODO: Convert the filter into a SQL query so we can take advantage of
@@ -162,7 +179,7 @@ class MessageBrowser(Container):
             if (msg_source := message.source) is not None:
                 source = format_message_source(msg_source)
 
-            timestamp = message.timestamp or datetime.now()
+            timestamp = message.timestamp or datetime.now(timezone.utc)
             key = table.add_row(
                 f"{timestamp:%H:%M:%S.%f}",
                 source,
@@ -175,3 +192,5 @@ class MessageBrowser(Container):
 
         if follow:
             table.action_scroll_bottom()
+        elif selected_key is not None and selected_key in self._messages:
+            table.move_cursor(row=table.get_row_index(selected_key), animate=False)

--- a/lib/lsp-devtools/tests/inspector/test_message_browser.py
+++ b/lib/lsp-devtools/tests/inspector/test_message_browser.py
@@ -9,11 +9,12 @@ from textual.app import ComposeResult
 from textual.widgets import DataTable
 
 from lsp_devtools.handlers.jsonrpc import JsonRPCMessage
+from lsp_devtools.handlers.sql import SqlHandler
 from lsp_devtools.inspector.message_browser import MessageBrowser
 
 
 def _message(method: str, msg_id: int) -> JsonRPCMessage:
-    return JsonRPCMessage.client(
+    message = JsonRPCMessage.client(
         {
             "jsonrpc": "2.0",
             "id": msg_id,
@@ -21,30 +22,12 @@ def _message(method: str, msg_id: int) -> JsonRPCMessage:
             "params": {},
         }
     )
-
-
-class _FakeDb:
-    def __init__(self) -> None:
-        self._rows: list[tuple[int, JsonRPCMessage]] = []
-
-    def add(self, message: JsonRPCMessage) -> None:
-        rowid = len(self._rows) + 1
-        message.metadata["timestamp"] = datetime.now(timezone.utc).isoformat(" ")
-        self._rows.append((rowid, message))
-
-    def find_messages(self, after: int = -1):
-        for rowid, message in self._rows:
-            if rowid > after:
-                yield rowid, message
-
-    def get_method_names(self) -> list[str]:
-        return sorted(
-            {m.method for _, m in self._rows if m.method is not None},
-        )
+    message.metadata["timestamp"] = datetime.now(timezone.utc)
+    return message
 
 
 class BrowserApp(App[None]):
-    def __init__(self, db: _FakeDb, *args, **kwargs):
+    def __init__(self, db: SqlHandler, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.db = db
 
@@ -55,9 +38,9 @@ class BrowserApp(App[None]):
 @pytest.mark.asyncio
 async def test_reload_preserves_selection_when_not_following():
     """New messages must not steal the selected row when follow=False (#247)."""
-    db = _FakeDb()
+    db = SqlHandler(":memory:")
     for i in range(3):
-        db.add(_message(f"method/{i}", i))
+        db.handle(_message(f"method/{i}", i))
 
     app = BrowserApp(db)
     async with app.run_test() as pilot:
@@ -72,7 +55,7 @@ async def test_reload_preserves_selection_when_not_following():
         await pilot.pause()
         selected = table.coordinate_to_cell_key(table.cursor_coordinate).row_key
 
-        db.add(_message("method/new", 99))
+        db.handle(_message("method/new", 99))
         browser.reload(follow=False)
         await pilot.pause()
 
@@ -84,9 +67,9 @@ async def test_reload_preserves_selection_when_not_following():
 @pytest.mark.asyncio
 async def test_reload_follows_tail_when_requested():
     """follow=True should select the newest message."""
-    db = _FakeDb()
+    db = SqlHandler(":memory:")
     for i in range(2):
-        db.add(_message(f"method/{i}", i))
+        db.handle(_message(f"method/{i}", i))
 
     app = BrowserApp(db)
     async with app.run_test() as pilot:
@@ -98,7 +81,7 @@ async def test_reload_follows_tail_when_requested():
         table.move_cursor(row=0, animate=False)
         await pilot.pause()
 
-        db.add(_message("method/new", 99))
+        db.handle(_message("method/new", 99))
         browser.reload(follow=True)
         await pilot.pause()
 
@@ -107,9 +90,9 @@ async def test_reload_follows_tail_when_requested():
 
 @pytest.mark.asyncio
 async def test_is_following_tail():
-    db = _FakeDb()
+    db = SqlHandler(":memory:")
     for i in range(3):
-        db.add(_message(f"method/{i}", i))
+        db.handle(_message(f"method/{i}", i))
 
     app = BrowserApp(db)
     async with app.run_test() as pilot:

--- a/lib/lsp-devtools/tests/inspector/test_message_browser.py
+++ b/lib/lsp-devtools/tests/inspector/test_message_browser.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+
+import pytest
+from textual.app import App
+from textual.app import ComposeResult
+from textual.widgets import DataTable
+
+from lsp_devtools.handlers.jsonrpc import JsonRPCMessage
+from lsp_devtools.inspector.message_browser import MessageBrowser
+
+
+def _message(method: str, msg_id: int) -> JsonRPCMessage:
+    return JsonRPCMessage.client(
+        {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "method": method,
+            "params": {},
+        }
+    )
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self._rows: list[tuple[int, JsonRPCMessage]] = []
+
+    def add(self, message: JsonRPCMessage) -> None:
+        rowid = len(self._rows) + 1
+        message.metadata["timestamp"] = datetime.now(timezone.utc).isoformat(" ")
+        self._rows.append((rowid, message))
+
+    def find_messages(self, after: int = -1):
+        for rowid, message in self._rows:
+            if rowid > after:
+                yield rowid, message
+
+    def get_method_names(self) -> list[str]:
+        return sorted(
+            {m.method for _, m in self._rows if m.method is not None},
+        )
+
+
+class BrowserApp(App[None]):
+    def __init__(self, db: _FakeDb, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.db = db
+
+    def compose(self) -> ComposeResult:
+        yield MessageBrowser()
+
+
+@pytest.mark.asyncio
+async def test_reload_preserves_selection_when_not_following():
+    """New messages must not steal the selected row when follow=False (#247)."""
+    db = _FakeDb()
+    for i in range(3):
+        db.add(_message(f"method/{i}", i))
+
+    app = BrowserApp(db)
+    async with app.run_test() as pilot:
+        browser = app.query_one(MessageBrowser)
+        table = browser.query_one(DataTable)
+
+        browser.reload()
+        await pilot.pause()
+        assert table.row_count == 3
+
+        table.move_cursor(row=1, animate=False)
+        await pilot.pause()
+        selected = table.coordinate_to_cell_key(table.cursor_coordinate).row_key
+
+        db.add(_message("method/new", 99))
+        browser.reload(follow=False)
+        await pilot.pause()
+
+        assert table.row_count == 4
+        assert table.coordinate_to_cell_key(table.cursor_coordinate).row_key == selected
+        assert table.cursor_row == 1
+
+
+@pytest.mark.asyncio
+async def test_reload_follows_tail_when_requested():
+    """follow=True should select the newest message."""
+    db = _FakeDb()
+    for i in range(2):
+        db.add(_message(f"method/{i}", i))
+
+    app = BrowserApp(db)
+    async with app.run_test() as pilot:
+        browser = app.query_one(MessageBrowser)
+        table = browser.query_one(DataTable)
+
+        browser.reload()
+        await pilot.pause()
+        table.move_cursor(row=0, animate=False)
+        await pilot.pause()
+
+        db.add(_message("method/new", 99))
+        browser.reload(follow=True)
+        await pilot.pause()
+
+        assert table.cursor_row == table.row_count - 1
+
+
+@pytest.mark.asyncio
+async def test_is_following_tail():
+    db = _FakeDb()
+    for i in range(3):
+        db.add(_message(f"method/{i}", i))
+
+    app = BrowserApp(db)
+    async with app.run_test() as pilot:
+        browser = app.query_one(MessageBrowser)
+        table = browser.query_one(DataTable)
+
+        browser.reload()
+        await pilot.pause()
+
+        table.move_cursor(row=table.row_count - 1, animate=False)
+        await pilot.pause()
+        assert browser.is_following_tail() is True
+
+        table.move_cursor(row=0, animate=False)
+        await pilot.pause()
+        assert browser.is_following_tail() is False


### PR DESCRIPTION
## Summary
- Fixes #247: inspector no longer steals selection when new LSP messages arrive
- Auto-follows the latest row only when the cursor is already on the last message
- Applies to both `lsp-devtools inspect` and the client inspector
## Test plan
- [x] `cd lib/lsp-devtools && hatch test` (or pytest on `tests/inspector/test_message_browser.py`)
- [x] Run `lsp-devtools inspect`, feed chatty traffic, select a middle row — selection should stick
- [x] Move to the last row — new messages should still follow the tail